### PR TITLE
garden: add .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: detect-private-key


### PR DESCRIPTION
## Summary
- Replays unique content from closed PR #256 (garden/git-tightening)
- Adds `.pre-commit-config.yaml` with basic hygiene hooks: trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files (500KB limit), detect-private-key

## Context
Audited all 24 closed-not-merged PRs. Only #256's pre-commit config was missing from current main. PRs #242 (docs scaffold) and #261 (SDK integration) content already exists in evolved form on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)