### PR TITLE
fix(ci): use PR head SHA for merge commit detection

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -44,7 +44,8 @@ jobs:
 
           # 2) Prevent merge commits in PR branch diff range.
           git fetch origin "$BASE_REF" --depth=1 || true
-          MERGES=$(git rev-list --merges "origin/$BASE_REF..HEAD" || true)
+          PR_HEAD="${{ github.event.pull_request.head.sha }}"
+          MERGES=$(git rev-list --merges "origin/$BASE_REF..$PR_HEAD" || true)
           if [[ -n "$MERGES" ]]; then
             echo "ERROR: merge commits detected in PR diff range:"
             echo "$MERGES"


### PR DESCRIPTION
## Summary
- Fixes false positive merge commit detection in policy-gate workflow
- GitHub Actions checks out a temporary merge commit as HEAD, which was being flagged by the linear history check
- Now uses the actual PR head SHA from the event payload instead

## Test plan
- [ ] Verify policy-gate passes on existing open PRs (especially dependabot)
- [ ] Verify policy-gate still catches real merge commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the accuracy of pull request validation by refining how the system identifies the range of commits to validate before merging. This ensures comprehensive pre-merge checks on all pull request changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->