### PR TITLE
chore: migrate to composite policy-gate action

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -18,39 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Enforce layered fix PR policy
-        shell: bash
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-          BASE_REF: ${{ github.base_ref }}
-          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
-        run: |
-          set -euo pipefail
-
-          echo "HEAD_REF=$HEAD_REF"
-          echo "BASE_REF=$BASE_REF"
-          echo "PR_LABELS=$PR_LABELS"
-
-          # 1) Fix branches must be layered; direct fix/* -> main/master is blocked unless explicitly overridden.
-          if [[ "$HEAD_REF" == fix/* ]]; then
-            if [[ "$BASE_REF" == "main" || "$BASE_REF" == "master" ]]; then
-              if [[ "$PR_LABELS" != *"layered-pr-exception"* ]]; then
-                echo "ERROR: fix/* PRs must target a layered branch, not main/master."
-                echo "Use stack/*, layer/*, release/*, or add label layered-pr-exception."
-                exit 1
-              fi
-            fi
-          fi
-
-          # 2) Prevent merge commits in PR branch diff range.
-          git fetch origin "$BASE_REF" --depth=1 || true
-          PR_HEAD="${{ github.event.pull_request.head.sha }}"
-          MERGES=$(git rev-list --merges "origin/$BASE_REF..$PR_HEAD" || true)
-          if [[ -n "$MERGES" ]]; then
-            echo "ERROR: merge commits detected in PR diff range:"
-            echo "$MERGES"
-            exit 1
-          fi
-
-          # 3) Local --no-verify cannot be detected directly; this server-side gate exists to prevent bypass outcomes.
-          echo "Policy gate passed."
+      - uses: KooshaPari/phenotypeActions/actions/policy-gate@main
+        with:
+          base_branch: main
+          block_merge_commits: true
+          require_layered_fix: true


### PR DESCRIPTION
Replaces inline policy-gate with reusable composite action from phenotypeActions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored CI policy enforcement workflow by moving verification logic to an external GitHub Action instead of maintaining custom inline scripts and environment variable configurations. The external action enforces merge-commit prevention and layered-fix requirements for pull requests targeting the main branch. All policy rules and enforcement behavior remain unchanged from the previous implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->