### PR TITLE
chore: migrate policy-gate to composite action

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -18,39 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Enforce layered fix PR policy
-        shell: bash
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-          BASE_REF: ${{ github.base_ref }}
-          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
-        run: |
-          set -euo pipefail
-
-          echo "HEAD_REF=$HEAD_REF"
-          echo "BASE_REF=$BASE_REF"
-          echo "PR_LABELS=$PR_LABELS"
-
-          # 1) Fix branches must be layered; direct fix/* -> main/master is blocked unless explicitly overridden.
-          if [[ "$HEAD_REF" == fix/* ]]; then
-            if [[ "$BASE_REF" == "main" || "$BASE_REF" == "master" ]]; then
-              if [[ "$PR_LABELS" != *"layered-pr-exception"* ]]; then
-                echo "ERROR: fix/* PRs must target a layered branch, not main/master."
-                echo "Use stack/*, layer/*, release/*, or add label layered-pr-exception."
-                exit 1
-              fi
-            fi
-          fi
-
-          # 2) Prevent merge commits in PR branch diff range.
-          git fetch origin "$BASE_REF" --depth=1 || true
-          PR_HEAD="${{ github.event.pull_request.head.sha }}"
-          MERGES=$(git rev-list --merges "origin/$BASE_REF..$PR_HEAD" || true)
-          if [[ -n "$MERGES" ]]; then
-            echo "ERROR: merge commits detected in PR diff range:"
-            echo "$MERGES"
-            exit 1
-          fi
-
-          # 3) Local --no-verify cannot be detected directly; this server-side gate exists to prevent bypass outcomes.
-          echo "Policy gate passed."
+      - uses: KooshaPari/phenotypeActions/actions/policy-gate@main
+        with:
+          base_branch: main
+          block_merge_commits: true
+          require_layered_fix: true


### PR DESCRIPTION
## Summary

- Replaces inline policy-gate script in `.github/workflows/policy-gate.yml` with the reusable composite action `KooshaPari/phenotypeActions/actions/policy-gate@main`
- Enforces `base_branch: main`, `block_merge_commits: true`, `require_layered_fix: true`

## Why

Centralizes policy enforcement logic in a single composite action maintained in `phenotypeActions`, eliminating drift across repos.

## Test plan
- [ ] Verify `policy-gate` job passes on this PR
- [ ] Confirm composite action is invoked (check Actions run logs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal policy enforcement workflow configuration through updated automation tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->