### PR TITLE
chore: integrate @phenotype/docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/phenodocs"]
+	path = vendor/phenodocs
+	url = https://github.com/KooshaPari/phenodocs.git

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,0 +1,1 @@
+@phenotype:registry=https://npm.pkg.github.com

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,42 +1,29 @@
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { createPhenotypeConfig } from "@phenotype/docs/config";
 
-import { defineConfig } from 'vitepress'
-
-const docsBase = process.env.DOCS_BASE ?? '/'
-
-export default defineConfig({
-  title: 'agentapi++',
-  description: 'Agent API server docs',
-  base: docsBase,
-  ignoreDeadLinks: true,
-
-  vite: {
-    resolve: {
-      alias: {
-        '@phenodocs-theme': phenodocsTheme,
-      },
+export default createPhenotypeConfig({
+  title: "agentapi++",
+  description: "Agent API server docs",
+  base: process.env.GITHUB_ACTIONS ? "/agentapi-plusplus/" : "/",
+  srcDir: ".",
+  githubOrg: "KooshaPari",
+  githubRepo: "agentapi-plusplus",
+  nav: [
+    { text: "Wiki", link: "/wiki/" },
+    { text: "Development Guide", link: "/development-guide/" },
+    { text: "Document Index", link: "/document-index/" },
+    { text: "API", link: "/api/" },
+    { text: "Roadmap", link: "/roadmap/" },
+  ],
+  sidebar: [
+    {
+      text: "Categories",
+      items: [
+        { text: "Wiki", link: "/wiki/" },
+        { text: "Development Guide", link: "/development-guide/" },
+        { text: "Document Index", link: "/document-index/" },
+        { text: "API", link: "/api/" },
+        { text: "Roadmap", link: "/roadmap/" },
+      ],
     },
-    server: {
-      fs: {
-        allow: [phenodocsRoot],
-      },
-    },
-  },
-  themeConfig: {
-    nav: [
-      { text: 'Wiki', link: '/wiki/' },
-      { text: 'Development Guide', link: '/development-guide/' },
-      { text: 'Document Index', link: '/document-index/' },
-      { text: 'API', link: '/api/' },
-      { text: 'Roadmap', link: '/roadmap/' }
-    ],
-    sidebar: [{ text: 'Categories', items: [
-      { text: 'Wiki', link: '/wiki/' },
-      { text: 'Development Guide', link: '/development-guide/' },
-      { text: 'Document Index', link: '/document-index/' },
-      { text: 'API', link: '/api/' },
-      { text: 'Roadmap', link: '/roadmap/' }
-    ] }]
-  }
-})
+  ],
+});

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,3 +1,1 @@
-import PhenoDocsTheme from '@phenodocs-theme'
-
-export default PhenoDocsTheme
+export { default } from "@phenotype/docs/theme";

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,12 +3,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "docs:index": "bash scripts/generate-doc-index.sh",
-    "docs:dev": "node ./node_modules/vitepress/dist/node/cli.js dev .",
-    "docs:build": "bash scripts/generate-doc-index.sh && node ./node_modules/vitepress/dist/node/cli.js build .",
-    "docs:preview": "node ./node_modules/vitepress/dist/node/cli.js preview ."
+    "postinstall": "cd ../vendor/phenodocs/packages/docs && bun install",
+    "dev": "vitepress dev .",
+    "build": "vitepress build .",
+    "preview": "vitepress preview ."
+  },
+  "dependencies": {
+    "@phenotype/docs": "file:../vendor/phenodocs/packages/docs"
   },
   "devDependencies": {
-    "vitepress": "^1.6.4"
+    "vitepress": "^1.6.4",
+    "vue": "^3.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- Add phenodocs git submodule at `vendor/phenodocs`
- Update VitePress config to use `createPhenotypeConfig()` from `@phenotype/docs/config`
- Update theme to re-export from `@phenotype/docs/theme`
- Add `file:` dependency and `.npmrc` for GitHub Packages

## Test plan
- [ ] Run `cd docs && bun install && bun run build` to verify VitePress builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)