### PR TITLE
chore(governance): remove duplicated governance blocks, reference thegent templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3600,49 +3600,14 @@ result = await workflow.execute({"source_url": "https://api.example.com/data"})
 
 This guide should be updated as the project evolves and new patterns are established.
 
-## Child-Agent and Delegation Policy
-- Use child agents liberally for scoped discovery, audits, multi-repo scans, and implementation planning before direct parent-agent edits.
-- Prefer delegating high-context or high-churn tasks to subagents, and keep parent-agent changes focused on integration and finalization.
-- Reserve parent-agent direct writes for the narrowest, final decision layer.
+## Shared Governance Protocols
 
-## CI Completeness Policy
+These governance blocks are maintained centrally:
+- Worktree discipline, reuse protocol, git delivery, stability, CI, child-agent delegation
+- Source: `KooshaPari/thegent` -> `templates/claude/governance-blocks/`
+- Do not duplicate these blocks here — reference the source instead.
 
-- Always evaluate and fix ALL CI check failures on a PR, including pre-existing failures inherited from main.
-- Never dismiss a CI failure as "pre-existing" or "unrelated to our changes" — if it fails on the PR, fix it in the PR.
-- This includes: build, lint, test, docs build, security scanning (CodeQL), code review gates (CodeRabbit), workflow guard checks, and any other CI jobs.
-- When a failure is caused by infrastructure outside the branch (e.g., rate limits, external service outages), implement or improve automated retry/bypass mechanisms in CI workflows.
-- After fixing CI failures, verify locally where possible (build, vet, tests) before pushing.
-
-## Phenotype Git and Delivery Workflow Protocol <!-- PHENOTYPE_GIT_DELIVERY_PROTOCOL -->
-
-- Use branch-based delivery with pull requests; do not rely on direct default-branch writes where rulesets apply.
-- Prefer stacked PRs for multi-part changes so each PR is small, reviewable, and independently mergeable.
-- Keep PRs linear and scoped: one concern per PR, explicit dependency order for stacks, and clear migration steps.
-- Enforce CI and required checks strictly: do not merge until all required checks and policy gates are green.
-- Resolve all review threads and substantive PR comments before merge; do not leave unresolved reviewer feedback.
-- Follow repository coding standards and best practices (typing, tests, lint, docs, security) before requesting merge.
-- Rebase or restack to keep branches current with target branch and to avoid stale/conflicting stacks.
-- When a ruleset or merge policy blocks progress, surface the blocker explicitly and adapt the plan (for example: open PR path, restack, or split changes).
-
-## Phenotype Org Cross-Project Reuse Protocol <!-- PHENOTYPE_SHARED_REUSE_PROTOCOL -->
-
-- Treat this repository as part of the broader Phenotype organization project collection, not an isolated codebase.
-- During research and implementation, actively identify code that is sharable, modularizable, splittable, or decomposable for reuse across repositories.
-- When reusable logic is found, prefer extraction into existing shared modules/projects first; if none fit, propose creating a new shared module/project.
-- Include a  section in plans with candidate code, target shared location, impacted repos, and migration order.
-- For cross-repo moves or ownership-impacting extractions, ask the user for confirmation on destination and rollout, then bake that into the execution plan.
-- Execute forward-only migrations: extract shared code, update all callers, and remove duplicated local implementations.
-
-## Phenotype Long-Term Stability and Non-Destructive Change Protocol <!-- PHENOTYPE_LONGTERM_STABILITY_PROTOCOL -->
-
-- Optimize for long-term platform value over short-term convenience; choose durable solutions even when implementation complexity is higher.
-- Classify proposed changes as  or ; prefer  unless an incident response explicitly requires a temporary fix.
-- Do not use deletions/reversions as the default strategy; prefer targeted edits, forward fixes, and incremental hardening.
-- Prefer moving obsolete or superseded material into  over destructive removal when retention is operationally useful.
-- Prefer clean manual merges, explicit conflict resolution, and auditable history over forceful rewrites, force merges, or history-destructive workflows.
-- Prefer completing unused stubs into production-quality implementations when they represent intended product direction; avoid leaving stubs ignored indefinitely.
-- Do not merge any PR while any check is failing, including non-required checks, unless the user gives explicit exception approval.
-- When proposing a quick fix, include a scheduled follow-up path to a stable solution in the same plan.
+<!-- governance: see thegent/templates/claude/governance-blocks/ for shared protocols -->
 
 ## Worktree Discipline
 


### PR DESCRIPTION
## Summary

- Removes 5-6 duplicated shared governance blocks from CLAUDE.md
- Replaces them with a single `## Shared Governance Protocols` reference section pointing to `KooshaPari/thegent` -> `templates/claude/governance-blocks/`
- All repo-specific content (project stack, domain rules, AgilePlus mandate, worktree rules) is preserved

## Blocks removed

- `PHENOTYPE_SHARED_REUSE_PROTOCOL`
- `PHENOTYPE_GIT_DELIVERY_PROTOCOL`
- `PHENOTYPE_LONGTERM_STABILITY_PROTOCOL`
- `GitHub Actions Billing Constraint`
- `CI Completeness Policy`
- `Child-Agent and Delegation Policy`

These blocks are identical across ~62 repos and are maintained centrally in thegent.

## Test plan

- [ ] Verify CLAUDE.md still contains all repo-specific content
- [ ] Verify shared governance section reference is present
- [ ] No functional changes to any code