### PR TITLE
chore(gitignore): add defensive patterns for node/rust/os/editors/logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,58 @@ __pycache__/
 .phenotype/
 config.db
 *.key
+
+# Node / JS
+node_modules/
+dist/
+build/
+.next/
+.nuxt/
+.svelte-kit/
+.turbo/
+.parcel-cache/
+.cache/
+coverage/
+*.tsbuildinfo
+.npm/
+.yarn/
+.pnpm-store/
+
+# Rust
+target/
+**/*.rs.bk
+
+# Env files
+.env.local
+.env.*.local
+.env.development.local
+.env.production.local
+.env.test.local
+
+# OS
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Editors
+.vscode/
+*.swp
+*.swo
+*~
+
+# Logs
+*.log
+logs/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Test artifacts
+.nyc_output/
+*.lcov
+test-results/
+playwright-report/
+
+# Worktrees (Phenotype convention)
+.worktrees/


### PR DESCRIPTION
## Summary
Adds defensive `.gitignore` patterns to prevent common build artifacts and OS/editor cruft from drifting into tracked state across multi-agent worktrees.

## Context
Local-drift audit on canonical `agentapi-plusplus` checkout showed 4,681 dirty files. Root cause was actually `vendor/` deletions (legitimately tracked Go vendored deps were locally removed), not `.gitignore` gaps. However, the existing `.gitignore` was missing common defensive patterns. This PR closes those gaps so future drift is caught.

## Patterns added
- **Node/JS**: `node_modules/`, `dist/`, `build/`, `.next/`, `.nuxt/`, `.svelte-kit/`, `.turbo/`, `.parcel-cache/`, `.cache/`, `coverage/`, `*.tsbuildinfo`, `.npm/`, `.yarn/`, `.pnpm-store/`
- **Rust**: `target/`, `**/*.rs.bk`
- **Env**: `.env.local`, `.env.*.local`, framework-specific env locals
- **OS**: `.DS_Store`, `Thumbs.db`, `desktop.ini`
- **Editors**: `.vscode/`, `*.swp`, `*.swo`, `*~`
- **Logs**: `*.log`, `logs/`, debug logs from npm/yarn/pnpm
- **Test artifacts**: `.nyc_output/`, `*.lcov`, `test-results/`, `playwright-report/`
- **Phenotype worktrees**: `.worktrees/`

## Note on local drift
The 4,681 dirty files in the canonical checkout are deletions of `vendor/` (which IS tracked intentionally — 4,679 files). That requires a `git checkout -- vendor/` or fresh clone locally; this PR does not address that.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to exclude common build artifacts and local/editor files, with no runtime or logic changes.
> 
> **Overview**
> Expands `.gitignore` with defensive patterns to prevent committing common Node/JS and Rust build outputs, local env variants, OS/editor cruft, logs, and test artifacts.
> 
> Also adds ignores for Phenotype worktree directories (`.worktrees/`) to reduce repo drift across multi-worktree setups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f73b9526701a47b73be5f542fbbe51006b0cc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->