### PR TITLE
fix(readme): correct API routes and required flags per user-story audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,23 @@ chmod +x agentapi
 ```
 
 > [!NOTE]
-> When using Claude, Codex, Opencode, Copilot, Gemini, Amp or CursorCLI, always specify the agent type explicitly (eg: `agentapi server --type=codex -- codex`), or message formatting may break.
+> Always specify the agent type explicitly using the `--type` flag (e.g: `agentapi server --type claude -- claude`), otherwise message formatting may break.
 
 An OpenAPI schema is available in [openapi.json](openapi.json).
 
-By default, the server runs on port 3284. Additionally, the server exposes the same OpenAPI schema at http://localhost:3284/openapi.json and the available endpoints in a documentation UI at http://localhost:3284/docs.
+By default, the server runs on port 3284. The server exposes the OpenAPI schema at http://localhost:3284/openapi.json.
 
-There are 4 endpoints:
+### Available Endpoints
+
+The server provides the following REST endpoints:
 
 - GET `/messages` - returns a list of all messages in the conversation with the agent
 - POST `/message` - sends a message to the agent. When a 200 response is returned, AgentAPI has detected that the agent started processing the message
 - GET `/status` - returns the current status of the agent, either "stable" or "running"
 - GET `/events` - an SSE stream of events from the agent: message and status updates
+- GET `/health` - health check endpoint
+- GET `/version` - server version information
+- GET `/info` - server and agent information
 
 #### Allowed hosts
 
@@ -62,15 +67,18 @@ go build -o agentapi main.go
 ### Run
 
 ```bash
-# Start with Claude Code
-./agentapi server -- claude
+# Start with Claude Code (REQUIRED: specify --type)
+./agentapi server --type claude -- claude
 
-# Start with specific agent
-./agentapi server -- cursor
-./agentapi server -- aider --model sonnet
+# Start with specific agent (REQUIRED: specify --type)
+./agentapi server --type cursor -- cursor
+./agentapi server --type aider -- aider
+
+# With specific model
+./agentapi server --type claude -- claude --model claude-3-5-sonnet-20241022
 ```
 
-Server runs on port 3284 with chat UI at http://localhost:3284/chat
+Server runs on port 3284. The chat interface is available at http://localhost:3284/chat (static HTML served from root, redirects to `/chat`).
 
 ---
 
@@ -84,36 +92,40 @@ Server runs on port 3284 with chat UI at http://localhost:3284/chat
 | Goose | `goose` | Independent agent |
 | Codex | `codex` | OpenAI's coding agent |
 | Gemini CLI | `gemini` | Google's CLI |
-| GitHub Copilot | `github-copilot` | GitHub's CLI |
+| GitHub Copilot | `copilot` | GitHub's CLI |
 | Sourcegraph Amp | `amp` | Sourcegraph's agent |
-| Amazon Q | `amazon-q` | AWS's developer agent |
+| Amazon Q | `q` | AWS's developer agent |
 | Auggie | `auggie` | Augment Code's agent |
 
 ---
 
-## API Endpoints
+## API Examples
 
-### Core
+### Send a Message
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/v0/chat` | POST | Send message, get response |
-| `/api/v0/agents` | GET | List supported agents |
-| `/api/v0/sessions` | GET | List active sessions |
-| `/api/v0/sessions/{id}` | GET | Get session details |
+```bash
+curl -X POST http://localhost:3284/message \
+  -H "Content-Type: application/json" \
+  -d '{"type":"user","content":"Hello, help me with Python"}'
+```
 
-### Streaming
+### Get Conversation History
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/v0/chat/stream` | POST | Streaming responses |
+```bash
+curl http://localhost:3284/messages
+```
 
-### Health
+### Check Agent Status
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/health` | GET | Health check |
-| `/metrics` | GET | Prometheus metrics |
+```bash
+curl http://localhost:3284/status
+```
+
+### Subscribe to Events (SSE)
+
+```bash
+curl http://localhost:3284/events
+```
 
 ---
 
@@ -122,36 +134,32 @@ Server runs on port 3284 with chat UI at http://localhost:3284/chat
 ```python
 import requests
 
-url = "http://localhost:3284/api/v0/chat"
+url = "http://localhost:3284/message"
 payload = {
-    "messages": [
-        {"role": "user", "content": "Hello, help me with Python"}
-    ],
-    "agent": "claude"
+    "type": "user",
+    "content": "Hello, help me with Python"
 }
 
 response = requests.post(url, json=payload)
 print(response.json())
+
+# Get history
+history = requests.get("http://localhost:3284/messages").json()
+print(history)
 ```
 
-### With Streaming
+### With Events (SSE)
 
 ```python
-import sseclient
 import requests
+import sseclient
 
-url = "http://localhost:3284/api/v0/chat/stream"
-payload = {
-    "messages": [{"role": "user", "content": "Write a hello world"}],
-    "agent": "claude"
-}
-
-response = requests.post(url, json=payload, stream=True)
+url = "http://localhost:3284/events"
+response = requests.get(url, stream=True)
 client = sseclient.SSEClient(response)
 
 for event in client.events():
-    if event.data:
-        print(event.data)
+    print(f"{event.event}: {event.data}")
 ```
 
 ---
@@ -193,8 +201,8 @@ for event in client.events():
 
 ```bash
 export AGENTAPI_PORT=3284
-export AGENTAPI_MODEL=claude-3-5-sonnet-20241022
-export AGENTAPI_TIMEOUT=300
+export AGENTAPI_ALLOWED_HOSTS="localhost,127.0.0.1"
+export AGENTAPI_ALLOWED_ORIGINS="http://localhost:3284"
 ```
 
 ### Config File
@@ -223,7 +231,7 @@ mcp:
   servers:
     agentapi:
       command: agentapi
-      args: ["server", "--", "claude"]
+      args: ["server", "--type", "claude", "--", "claude"]
 ```
 
 ### With cliproxy++
@@ -231,7 +239,7 @@ mcp:
 Route LLM requests through cliproxy++ for cost optimization:
 
 ```bash
-./agentapi server -- claude --llm-provider http://localhost:8317
+./agentapi server --type claude -- claude --llm-provider http://localhost:8317
 ```
 
 ---


### PR DESCRIPTION
## **User description**
## Summary

Fixes all documentation errors identified in the user-story audit. Every Quick Start example in the README returns 404 because it references non-existent endpoints and omits required flags.

## Findings from User Story Audit
See: `docs/governance/userstory-agentapi-plusplus-firstrun-2026-04-26.md`

### Issue 1: Endpoint Routes Are Wrong
- **README claimed**: `/api/v0/chat`, `/api/v0/agents`, `/api/v0/sessions`, `/api/v0/chat/stream`
- **Code implements**: Root-level endpoints (`/message`, `/messages`, `/status`, `/events`, `/health`, `/version`, `/info`)
- **Result**: All Quick Start curl examples return 404
- **Verified against**: `lib/httpapi/server.go` route definitions

### Issue 2: Missing Required Flag in Examples
- **README examples omit**: `--type=<agent>` flag (required by server CLI)
- **Server expects**: `agentapi-plusplus server --type claude -- my-agent`
- **Result**: Quick Start fails at first command
- **Verified against**: `cmd/server/server.go` CLI flag requirements

### Issue 3: Non-existent UI Endpoint
- **README claimed**: `localhost:3284/chat` as admin/management UI
- **Code provides**: Static chat files served at `/chat/*`, redirects `/` to `/chat`
- **Result**: Misleading documentation about what UI endpoint does

## Changes Made
- Removed all `/api/v0/*` endpoint references
- Added `--type` flag to all server CLI examples  
- Updated all curl examples to use actual endpoints (`/message`, `/messages`, `/status`, `/events`)
- Clarified chat interface availability
- Corrected agent type flags (e.g., `q` vs `amazon-q`, `copilot` vs `github-copilot`)
- Added additional available endpoints (`/health`, `/version`, `/info`)

## Testing
- Verified against `lib/httpapi/server.go` route definitions
- Confirmed via `cmd/server/server.go` CLI flag requirements
- All endpoint paths match current implementation
- No code changes—documentation only

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates that change no runtime behavior; risk is limited to potential confusion if any examples remain inaccurate.
> 
> **Overview**
> Updates `README.md` to match the server’s actual root-level API routes, replacing the incorrect `/api/v0/*` examples with `/message`, `/messages`, `/status`, and `/events`, and listing additional endpoints like `/health`, `/version`, and `/info`.
> 
> All quick-start and integration commands are revised to explicitly include the `--type` agent flag, and the supported agent type names are corrected (e.g., `copilot`, `q`). Python and curl snippets are updated accordingly, and the chat UI description is clarified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b92be018d586bedcfe4f3175cd2f7fd31ec1654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Correct the README for the current server routes and required startup flags**

### What Changed
- Replaced the outdated `/api/v0/*` examples with the actual endpoints users can call now, including message history, status, event stream, health, version, and info
- Updated all quick-start commands to include the required `--type` flag so the server starts correctly
- Clarified where the chat interface lives and removed the claim that a docs UI is available at `/docs`
- Fixed agent type names in examples and updated code samples to match the current request format

### Impact
`✅ Fewer 404s from README examples`
`✅ Shorter setup time for new users`
`✅ Fewer startup failures from missing agent type`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=l5-wvG_cUlJRW9wDKdNy4F33n2Ulmz9_WWv-ykTlUrY&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
