### PR TITLE
chore(gitignore): explicit docs/node_modules/ (Scorecard FP cleanup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ playwright-report/
 
 # Worktree directories (org policy)
 .claude/worktrees/
+
+
+# Docs node_modules explicit (Scorecard BinaryArtifacts FP cleanup)
+docs/node_modules/


### PR DESCRIPTION
Add explicit docs/node_modules/ entry to .gitignore for Scorecard BinaryArtifacts (6 alerts). The recursive node_modules/ pattern already covers this, but explicit entry documents the audit cleanup intent.

Note: existing committed files require git-filter-repo to remove from history; this PR only prevents future commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to `.gitignore`, only affecting which files can be newly tracked/committed. No runtime behavior or production code is impacted.
> 
> **Overview**
> Adds an explicit `.gitignore` entry for `docs/node_modules/` (in addition to the existing `node_modules/` ignore) to document and prevent future inclusion of docs dependency artifacts, addressing Scorecard BinaryArtifacts false positives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf4d5db79756352e568b61e76e5c0b033aae1a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->