### PR TITLE
taskfile common tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -85,12 +85,7 @@ tasks:
           export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
           mkdir -p "$GOTMPDIR"
-          fmt_out=$(gofmt -l .)
-          if [ -n "$fmt_out" ]; then
-            printf "%s\n" "$fmt_out"
-            exit 1
-          fi
-          go vet ./...
+          git ls-files "*.go" | xargs -n1 dirname | sort -u | xargs -I{} go vet ./{}
         '
 
   lint:chat:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,10 +30,10 @@ tasks:
     cmds:
       - |
         bash -euo pipefail -c '
-          rm -rf .next
           if [ ! -d node_modules ]; then
             bun install --frozen-lockfile
           fi
+          rm -f .next/lock
           bun run build
         '
 
@@ -85,7 +85,12 @@ tasks:
           export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
           mkdir -p "$GOTMPDIR"
-          git ls-files "*.go" | xargs -n1 dirname | sort -u | xargs -I{} go vet ./{}
+          fmt_out=$(gofmt -l .)
+          if [ -n "$fmt_out" ]; then
+            printf "%s\n" "$fmt_out"
+            exit 1
+          fi
+          go vet ./...
         '
 
   lint:chat:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,7 +16,9 @@ tasks:
       - |
         bash -euo pipefail -c '
           export GOCACHE="$PWD/.cache/go-build"
+          export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
+          mkdir -p "$GOTMPDIR"
           go build -o ./agentapi ./main.go
         '
 
@@ -26,17 +28,26 @@ tasks:
       - test ! -f package.json
     dir: chat
     cmds:
-      - bun install --frozen-lockfile
-      - bun run build
+      - |
+        bash -euo pipefail -c '
+          rm -rf .next
+          if [ ! -d node_modules ]; then
+            bun install --frozen-lockfile
+          fi
+          bun run build
+        '
 
   build:docs:
     internal: true
     status:
-      - test ! -f package.json
+      - test ! -f package.json || test ! -d ../vendor/phenodocs/packages/docs
     dir: docs
     cmds:
-      - npm install
-      - npm run build
+      - |
+        bash -euo pipefail -c '
+          npm ci --ignore-scripts
+          node ./node_modules/vitepress/dist/node/cli.js build .
+        '
 
   test:
     desc: Run tests for detected language targets.
@@ -51,7 +62,9 @@ tasks:
       - |
         bash -euo pipefail -c '
           export GOCACHE="$PWD/.cache/go-build"
+          export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
+          mkdir -p "$GOTMPDIR"
           go test -short ./...
         '
 
@@ -69,7 +82,14 @@ tasks:
       - |
         bash -euo pipefail -c '
           export GOCACHE="$PWD/.cache/go-build"
+          export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
+          mkdir -p "$GOTMPDIR"
+          fmt_out=$(gofmt -l .)
+          if [ -n "$fmt_out" ]; then
+            printf "%s\n" "$fmt_out"
+            exit 1
+          fi
           go vet ./...
         '
 
@@ -77,10 +97,15 @@ tasks:
     internal: true
     status:
       - test ! -f chat/package.json
-    dir: chat
     cmds:
-      - bun install --frozen-lockfile
-      - bun run lint
+      - |
+        bash -euo pipefail -c '
+          cd chat
+          if [ ! -d node_modules ]; then
+            bun install --frozen-lockfile
+          fi
+          bun run lint
+        '
 
   clean:
     desc: Remove generated build artifacts.
@@ -98,13 +123,15 @@ tasks:
         python3 - <<'PY'
         from pathlib import Path
         import os
-        import subprocess
         import shutil
+        import subprocess
 
         os.environ["GOCACHE"] = str(Path(".cache/go-build").resolve())
+        os.environ["GOTMPDIR"] = str(Path(".cache/go-tmp").resolve())
         Path(os.environ["GOCACHE"]).mkdir(parents=True, exist_ok=True)
+        Path(os.environ["GOTMPDIR"]).mkdir(parents=True, exist_ok=True)
         subprocess.run(["go", "clean", "-cache", "-testcache"], check=True)
-        for path in [Path("agentapi"), Path("coverage.out"), Path(".cache/go-build")]:
+        for path in [Path("agentapi"), Path(".cache/go-build"), Path(".cache/go-tmp")]:
             if path.is_file() or path.is_symlink():
                 path.unlink()
             elif path.is_dir():
@@ -136,7 +163,7 @@ tasks:
         from pathlib import Path
         import shutil
 
-        for path in [Path("docs/.vitepress/dist"), Path("docs/.vitepress/cache"), Path("docs/.generated")]:
+        for path in [Path("docs/.vitepress/cache")]:
             if path.exists():
                 shutil.rmtree(path)
         PY

--- a/agentapi-plusplus/Taskfile.yml
+++ b/agentapi-plusplus/Taskfile.yml
@@ -85,12 +85,7 @@ tasks:
           export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
           mkdir -p "$GOTMPDIR"
-          fmt_out=$(gofmt -l .)
-          if [ -n "$fmt_out" ]; then
-            printf "%s\n" "$fmt_out"
-            exit 1
-          fi
-          go vet ./...
+          git ls-files "*.go" | xargs -n1 dirname | sort -u | xargs -I{} go vet ./{}
         '
 
   lint:chat:

--- a/agentapi-plusplus/Taskfile.yml
+++ b/agentapi-plusplus/Taskfile.yml
@@ -30,10 +30,10 @@ tasks:
     cmds:
       - |
         bash -euo pipefail -c '
-          rm -rf .next
           if [ ! -d node_modules ]; then
             bun install --frozen-lockfile
           fi
+          rm -f .next/lock
           bun run build
         '
 
@@ -85,7 +85,12 @@ tasks:
           export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
           mkdir -p "$GOTMPDIR"
-          git ls-files "*.go" | xargs -n1 dirname | sort -u | xargs -I{} go vet ./{}
+          fmt_out=$(gofmt -l .)
+          if [ -n "$fmt_out" ]; then
+            printf "%s\n" "$fmt_out"
+            exit 1
+          fi
+          go vet ./...
         '
 
   lint:chat:

--- a/agentapi-plusplus/Taskfile.yml
+++ b/agentapi-plusplus/Taskfile.yml
@@ -16,7 +16,9 @@ tasks:
       - |
         bash -euo pipefail -c '
           export GOCACHE="$PWD/.cache/go-build"
+          export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
+          mkdir -p "$GOTMPDIR"
           go build -o ./agentapi ./main.go
         '
 
@@ -26,17 +28,26 @@ tasks:
       - test ! -f package.json
     dir: chat
     cmds:
-      - bun install --frozen-lockfile
-      - bun run build
+      - |
+        bash -euo pipefail -c '
+          rm -rf .next
+          if [ ! -d node_modules ]; then
+            bun install --frozen-lockfile
+          fi
+          bun run build
+        '
 
   build:docs:
     internal: true
     status:
-      - test ! -f package.json
+      - test ! -f package.json || test ! -d ../vendor/phenodocs/packages/docs
     dir: docs
     cmds:
-      - npm install
-      - npm run build
+      - |
+        bash -euo pipefail -c '
+          npm ci --ignore-scripts
+          node ./node_modules/vitepress/dist/node/cli.js build .
+        '
 
   test:
     desc: Run tests for detected language targets.
@@ -51,7 +62,9 @@ tasks:
       - |
         bash -euo pipefail -c '
           export GOCACHE="$PWD/.cache/go-build"
+          export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
+          mkdir -p "$GOTMPDIR"
           go test -short ./...
         '
 
@@ -69,7 +82,14 @@ tasks:
       - |
         bash -euo pipefail -c '
           export GOCACHE="$PWD/.cache/go-build"
+          export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
+          mkdir -p "$GOTMPDIR"
+          fmt_out=$(gofmt -l .)
+          if [ -n "$fmt_out" ]; then
+            printf "%s\n" "$fmt_out"
+            exit 1
+          fi
           go vet ./...
         '
 
@@ -77,10 +97,15 @@ tasks:
     internal: true
     status:
       - test ! -f chat/package.json
-    dir: chat
     cmds:
-      - bun install --frozen-lockfile
-      - bun run lint
+      - |
+        bash -euo pipefail -c '
+          cd chat
+          if [ ! -d node_modules ]; then
+            bun install --frozen-lockfile
+          fi
+          bun run lint
+        '
 
   clean:
     desc: Remove generated build artifacts.
@@ -98,13 +123,15 @@ tasks:
         python3 - <<'PY'
         from pathlib import Path
         import os
-        import subprocess
         import shutil
+        import subprocess
 
         os.environ["GOCACHE"] = str(Path(".cache/go-build").resolve())
+        os.environ["GOTMPDIR"] = str(Path(".cache/go-tmp").resolve())
         Path(os.environ["GOCACHE"]).mkdir(parents=True, exist_ok=True)
+        Path(os.environ["GOTMPDIR"]).mkdir(parents=True, exist_ok=True)
         subprocess.run(["go", "clean", "-cache", "-testcache"], check=True)
-        for path in [Path("agentapi"), Path("coverage.out"), Path(".cache/go-build")]:
+        for path in [Path("agentapi"), Path(".cache/go-build"), Path(".cache/go-tmp")]:
             if path.is_file() or path.is_symlink():
                 path.unlink()
             elif path.is_dir():
@@ -136,7 +163,7 @@ tasks:
         from pathlib import Path
         import shutil
 
-        for path in [Path("docs/.vitepress/dist"), Path("docs/.vitepress/cache"), Path("docs/.generated")]:
+        for path in [Path("docs/.vitepress/cache")]:
             if path.exists():
                 shutil.rmtree(path)
         PY


### PR DESCRIPTION
- **chore: harden taskfile common tasks**
- **Add common Taskfile targets**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/lint automation changes only; main risk is CI/build behavior differences (dependency install strategy, formatting enforcement, and adjusted cleanup paths).
> 
> **Overview**
> **Hardens common Taskfile targets** for Go, chat, and docs in both `Taskfile.yml` and `agentapi-plusplus/Taskfile.yml`.
> 
> Go tasks now set and create `GOTMPDIR` alongside `GOCACHE`, `lint:go` fails CI on unformatted files via `gofmt -l`, and `clean:go` also removes the new temp dir. Chat build/lint now avoid re-installing dependencies when `node_modules` exists and remove `.next/lock` before building.
> 
> Docs build switches to `npm ci --ignore-scripts` and runs the VitePress CLI directly, gates the task when vendored docs are present, and `clean:docs` is narrowed to only remove the VitePress cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4676b74f4c5584bdae3fa8422fbf7f68fcb5c386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->