### PR TITLE
chore: add go taskfile common tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,174 +1,61 @@
 version: '3'
 
 vars:
-  DETECTED_LANGUAGES: Go, Bun/Node
+  DETECTED_LANGUAGE: Go
 
 tasks:
   default:
-    desc: List common tasks for detected language targets.
+    desc: List available tasks.
     cmds:
       - task --list
 
   build:
-    desc: Build every detected language target ({{.DETECTED_LANGUAGES}}).
-    cmds:
-      - task: build:go
-      - task: build:chat
-      - task: build:docs
-
-  build:go:
-    internal: true
-    status:
-      - test ! -f go.mod
+    desc: Build the {{.DETECTED_LANGUAGE}} binary.
     cmds:
       - |
         bash -euo pipefail -c '
           export GOCACHE="$PWD/.cache/go-build"
-          export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
-          mkdir -p "$GOTMPDIR"
           go build -o ./agentapi ./main.go
         '
 
-  build:chat:
-    internal: true
-    status:
-      - test ! -f package.json
-    dir: chat
-    cmds:
-      - |
-        bash -euo pipefail -c '
-          if [ ! -d node_modules ]; then
-            bun install --frozen-lockfile
-          fi
-          rm -f .next/lock
-          bun run build
-        '
-
-  build:docs:
-    internal: true
-    status:
-      - test ! -f package.json || test ! -d ../vendor/phenodocs/packages/docs
-    dir: docs
-    cmds:
-      - |
-        bash -euo pipefail -c '
-          npm ci --ignore-scripts
-          node ./node_modules/vitepress/dist/node/cli.js build .
-        '
-
   test:
-    desc: Run tests for detected language targets ({{.DETECTED_LANGUAGES}}).
-    cmds:
-      - task: test:go
-
-  test:go:
-    internal: true
-    status:
-      - test ! -f go.mod
+    desc: Run the {{.DETECTED_LANGUAGE}} test suite.
     cmds:
       - |
         bash -euo pipefail -c '
           export GOCACHE="$PWD/.cache/go-build"
-          export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
-          mkdir -p "$GOTMPDIR"
           go test -short ./...
         '
 
   lint:
-    desc: Run linters for detected language targets ({{.DETECTED_LANGUAGES}}).
+    desc: Run {{.DETECTED_LANGUAGE}} vet checks.
     cmds:
-      - task: lint:go
-      - task: lint:chat
-
-  lint:go:
-    internal: true
-    status:
-      - test ! -f go.mod
-    cmds:
+      - task --list >/dev/null
       - |
         bash -euo pipefail -c '
           export GOCACHE="$PWD/.cache/go-build"
-          export GOTMPDIR="$PWD/.cache/go-tmp"
           mkdir -p "$GOCACHE"
-          mkdir -p "$GOTMPDIR"
-          git ls-files "*.go" ":!:agentapi-plusplus/**" | xargs gofmt -l | tee /tmp/agentapi-gofmt.out
-          test ! -s /tmp/agentapi-gofmt.out
-          go list ./... | xargs go vet
-        '
-
-  lint:chat:
-    internal: true
-    status:
-      - test ! -f chat/package.json
-    cmds:
-      - |
-        bash -euo pipefail -c '
-          cd chat
-          if [ ! -d node_modules ]; then
-            bun install --frozen-lockfile
-          fi
-          bun run lint
+          go list ./... | grep -Ev "/agentapi-plusplus($|/)" | xargs go vet
         '
 
   clean:
-    desc: Remove generated build artifacts for detected language targets ({{.DETECTED_LANGUAGES}}).
-    cmds:
-      - task: clean:go
-      - task: clean:chat
-      - task: clean:docs
-
-  clean:go:
-    internal: true
-    status:
-      - test ! -f go.mod
+    desc: Remove generated {{.DETECTED_LANGUAGE}} build artifacts.
     cmds:
       - |
         python3 - <<'PY'
-        from pathlib import Path
         import os
+        from pathlib import Path
         import shutil
         import subprocess
 
         os.environ["GOCACHE"] = str(Path(".cache/go-build").resolve())
-        os.environ["GOTMPDIR"] = str(Path(".cache/go-tmp").resolve())
         Path(os.environ["GOCACHE"]).mkdir(parents=True, exist_ok=True)
-        Path(os.environ["GOTMPDIR"]).mkdir(parents=True, exist_ok=True)
-        subprocess.run(["go", "clean", "-cache", "-testcache"], check=True)
-        for path in [Path("agentapi"), Path(".cache/go-build"), Path(".cache/go-tmp")]:
+        subprocess.run(["go", "clean", "-cache", "-testcache"], check=False)
+        for path in [Path("agentapi"), Path(".cache/go-build")]:
             if path.is_file() or path.is_symlink():
                 path.unlink()
             elif path.is_dir():
-                shutil.rmtree(path)
-        PY
-
-  clean:chat:
-    internal: true
-    status:
-      - test ! -f chat/package.json
-    cmds:
-      - |
-        python3 - <<'PY'
-        from pathlib import Path
-        import shutil
-
-        for path in [Path("chat/.next"), Path("chat/out"), Path("chat/.turbo")]:
-            if path.exists():
-                shutil.rmtree(path)
-        PY
-
-  clean:docs:
-    internal: true
-    status:
-      - test ! -f docs/package.json
-    cmds:
-      - |
-        python3 - <<'PY'
-        from pathlib import Path
-        import shutil
-
-        for path in [Path("docs/.vitepress/cache")]:
-            if path.exists():
-                shutil.rmtree(path)
+                shutil.rmtree(path, ignore_errors=True)
         PY


### PR DESCRIPTION
## **User description**
Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer task automation and cleanup behavior, with no runtime code or production logic impact.
> 
> **Overview**
> Consolidates `Taskfile.yml` from a multi-target (Go/Node/docs) setup into a **Go-only** taskfile with simplified `default`, `build`, `test`, `lint`, and `clean` tasks.
> 
> `lint` now runs `go vet` while excluding `agentapi-plusplus` packages, and `clean` is made more forgiving (`go clean` not required to succeed; directory removal uses `ignore_errors`) while dropping `GOTMPDIR` handling and removing chat/docs cleanup tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 947291588d913ea00e68e178fa68cf0d7e5f892e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Simplify project tasks to Go-only commands**

### What Changed
- The task list now shows only Go-focused commands instead of mixed Go, Node, and docs tasks
- Build and test now run the Go app and test suite only, without creating a separate temp cache directory
- Lint now runs Go vet checks and skips the `agentapi-plusplus` path
- Clean now removes Go build artifacts even if `go clean` fails, and it no longer tries to clear chat or docs outputs

### Impact
`✅ Simpler task commands`
`✅ Fewer cleanup failures`
`✅ Faster Go-only maintenance`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=k_cqEdamWLAJZwU2jNtviy5KxzF5ilanMSIVUVka0iY&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
