### PR TITLE
Add common Taskfile tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,6 +14,8 @@ tasks:
     cmds:
       - |
         bash -euo pipefail -c '
+          export PATH="/opt/homebrew/bin:$PATH"
+          export GOTOOLCHAIN=local
           export GOCACHE="$PWD/.cache/go-build"
           mkdir -p "$GOCACHE"
           go build -o ./agentapi ./main.go
@@ -24,6 +26,8 @@ tasks:
     cmds:
       - |
         bash -euo pipefail -c '
+          export PATH="/opt/homebrew/bin:$PATH"
+          export GOTOOLCHAIN=local
           export GOCACHE="$PWD/.cache/go-build"
           mkdir -p "$GOCACHE"
           go test -short ./...
@@ -35,9 +39,11 @@ tasks:
       - task --list >/dev/null
       - |
         bash -euo pipefail -c '
+          export PATH="/opt/homebrew/bin:$PATH"
+          export GOTOOLCHAIN=local
           export GOCACHE="$PWD/.cache/go-build"
           mkdir -p "$GOCACHE"
-          go list ./... | grep -Ev "/agentapi-plusplus($|/)" | xargs go vet
+          go vet ./cmd/... ./internal/... ./lib/... ./x/...
         '
 
   clean:
@@ -50,6 +56,8 @@ tasks:
         import shutil
         import subprocess
 
+        os.environ["PATH"] = "/opt/homebrew/bin:" + os.environ.get("PATH", "")
+        os.environ["GOTOOLCHAIN"] = "local"
         os.environ["GOCACHE"] = str(Path(".cache/go-build").resolve())
         Path(os.environ["GOCACHE"]).mkdir(parents=True, exist_ok=True)
         subprocess.run(["go", "clean", "-cache", "-testcache"], check=False)


### PR DESCRIPTION
## **User description**
Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build tooling change limited to Taskfile commands; main impact is potential environment/path assumptions on non-Homebrew setups and slightly different `go vet` coverage.
> 
> **Overview**
> Updates `Taskfile.yml` to force use of the local Go toolchain (`GOTOOLCHAIN=local`) and prepend Homebrew’s Go path for `build`, `test`, `lint`, and `clean` tasks.
> 
> Also simplifies `lint` by replacing a `go list | grep ... | xargs go vet` pipeline with an explicit `go vet` over `./cmd/... ./internal/... ./lib/... ./x/...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4b5e3ed3f68e4034f6530eb5e7842a19aa6e6e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Make the common build, test, lint, and clean tasks run with the local Go toolchain

### What Changed
- Build, test, lint, and clean tasks now use the local Go toolchain and Homebrew Go path, which makes the tasks work in more development setups.
- Lint now runs vet checks directly across the main project folders instead of relying on a filtered package list.
- Clean now also clears Go cache state using the same local setup as the other tasks.

### Impact
`✅ Fewer task failures on local machines`
`✅ More consistent build and test runs`
`✅ Clearer vet coverage for core project code`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=soXm-LEFLmL7Uji70RUGZW4YCp1DCJSr-YqkRJH0t6I&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
