### PR TITLE
chore: expand common taskfile targets

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,69 +1,176 @@
 version: '3'
 
 vars:
-  DETECTED_LANGUAGE: Go
+  DETECTED_LANGUAGES: Go, Bun/Node
 
 tasks:
   default:
-    desc: List available tasks.
+    desc: List common tasks for detected language targets.
     cmds:
       - task --list
 
   build:
-    desc: Build the {{.DETECTED_LANGUAGE}} binary.
+    desc: Build detected language targets ({{.DETECTED_LANGUAGES}}).
+    cmds:
+      - task: build:go
+      - task: build:chat
+      - task: build:docs
+
+  build:go:
+    internal: true
+    status:
+      - test ! -f go.mod
     cmds:
       - |
         bash -euo pipefail -c '
-          export PATH="/opt/homebrew/bin:$PATH"
-          export GOTOOLCHAIN=local
           export GOCACHE="$PWD/.cache/go-build"
-          mkdir -p "$GOCACHE"
+          export GOTMPDIR="$PWD/.cache/go-tmp"
+          mkdir -p "$GOCACHE" "$GOTMPDIR"
           go build -o ./agentapi ./main.go
         '
 
-  test:
-    desc: Run the {{.DETECTED_LANGUAGE}} test suite.
+  build:chat:
+    internal: true
+    status:
+      - test ! -f package.json
+    dir: chat
     cmds:
       - |
         bash -euo pipefail -c '
-          export PATH="/opt/homebrew/bin:$PATH"
-          export GOTOOLCHAIN=local
+          if [ ! -d node_modules ]; then
+            bun install --frozen-lockfile
+          fi
+          bun run build
+        '
+
+  build:docs:
+    internal: true
+    status:
+      - test ! -f package.json || test ! -d ../vendor/phenodocs/packages/docs
+    dir: docs
+    cmds:
+      - |
+        bash -euo pipefail -c '
+          npm ci --ignore-scripts
+          npm run build
+        '
+
+  test:
+    desc: Run tests for detected language targets ({{.DETECTED_LANGUAGES}}).
+    cmds:
+      - task: test:go
+
+  test:go:
+    internal: true
+    status:
+      - test ! -f go.mod
+    cmds:
+      - |
+        bash -euo pipefail -c '
           export GOCACHE="$PWD/.cache/go-build"
-          mkdir -p "$GOCACHE"
+          export GOTMPDIR="$PWD/.cache/go-tmp"
+          mkdir -p "$GOCACHE" "$GOTMPDIR"
           go test -short ./...
         '
 
   lint:
-    desc: Run {{.DETECTED_LANGUAGE}} vet checks.
+    desc: Run linters for detected language targets ({{.DETECTED_LANGUAGES}}).
+    cmds:
+      - task: lint:taskfile
+      - task: lint:go
+      - task: lint:chat
+
+  lint:taskfile:
+    internal: true
     cmds:
       - task --list >/dev/null
+
+  lint:go:
+    internal: true
+    status:
+      - test ! -f go.mod
+    cmds:
       - |
         bash -euo pipefail -c '
-          export PATH="/opt/homebrew/bin:$PATH"
-          export GOTOOLCHAIN=local
           export GOCACHE="$PWD/.cache/go-build"
-          mkdir -p "$GOCACHE"
-          go vet ./cmd/... ./internal/... ./lib/... ./x/...
+          export GOTMPDIR="$PWD/.cache/go-tmp"
+          mkdir -p "$GOCACHE" "$GOTMPDIR"
+          git ls-files "*.go" ":!:agentapi-plusplus/**" | xargs gofmt -l | tee /tmp/agentapi-gofmt.out
+          test ! -s /tmp/agentapi-gofmt.out
+          go list ./... | xargs go vet
+        '
+
+  lint:chat:
+    internal: true
+    status:
+      - test ! -f package.json
+    dir: chat
+    cmds:
+      - |
+        bash -euo pipefail -c '
+          if [ ! -d node_modules ]; then
+            bun install --frozen-lockfile
+          fi
+          bun run lint
         '
 
   clean:
-    desc: Remove generated {{.DETECTED_LANGUAGE}} build artifacts.
+    desc: Remove generated build artifacts for detected language targets ({{.DETECTED_LANGUAGES}}).
+    cmds:
+      - task: clean:go
+      - task: clean:chat
+      - task: clean:docs
+
+  clean:go:
+    internal: true
+    status:
+      - test ! -f go.mod
     cmds:
       - |
         python3 - <<'PY'
-        import os
         from pathlib import Path
+        import os
         import shutil
         import subprocess
 
-        os.environ["PATH"] = "/opt/homebrew/bin:" + os.environ.get("PATH", "")
-        os.environ["GOTOOLCHAIN"] = "local"
         os.environ["GOCACHE"] = str(Path(".cache/go-build").resolve())
+        os.environ["GOTMPDIR"] = str(Path(".cache/go-tmp").resolve())
         Path(os.environ["GOCACHE"]).mkdir(parents=True, exist_ok=True)
-        subprocess.run(["go", "clean", "-cache", "-testcache"], check=False)
-        for path in [Path("agentapi"), Path(".cache/go-build")]:
+        Path(os.environ["GOTMPDIR"]).mkdir(parents=True, exist_ok=True)
+        subprocess.run(["go", "clean", "-cache", "-testcache"], check=True)
+        for path in [Path("agentapi"), Path(".cache/go-build"), Path(".cache/go-tmp")]:
             if path.is_file() or path.is_symlink():
                 path.unlink()
             elif path.is_dir():
-                shutil.rmtree(path, ignore_errors=True)
+                shutil.rmtree(path)
+        PY
+
+  clean:chat:
+    internal: true
+    status:
+      - test ! -f chat/package.json
+    cmds:
+      - |
+        python3 - <<'PY'
+        from pathlib import Path
+        import shutil
+
+        for path in [Path("chat/.next"), Path("chat/out"), Path("chat/.turbo")]:
+            if path.exists():
+                shutil.rmtree(path)
+        PY
+
+  clean:docs:
+    internal: true
+    status:
+      - test ! -f docs/package.json
+    cmds:
+      - |
+        python3 - <<'PY'
+        from pathlib import Path
+        import shutil
+
+        for path in [Path("docs/.vitepress/cache")]:
+            if path.exists():
+                shutil.rmtree(path)
         PY


### PR DESCRIPTION
## **User description**
Detect the root Go module and Bun/Node targets so build, test, lint, and clean cover the runnable repo surfaces while skipping unavailable vendored docs dependencies.

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/test/lint/clean automation is broadened across Go and Bun/Node targets and could change local dev/CI behavior, but it does not affect runtime application logic.
> 
> **Overview**
> Updates `Taskfile.yml` to run **build/lint/clean** across multiple detected targets (Go binary, `chat` Bun project, and `docs` Node build), with per-target `status` checks to skip tasks when dependencies/files aren’t present.
> 
> Go tasks now use `GOCACHE` + `GOTMPDIR`, `lint:go` enforces `gofmt` (excluding `agentapi-plusplus/**`) and runs `go vet` over all packages, and `clean:go` also removes the new tmp/cache dirs. Adds dedicated cleaners for `chat` (`.next`, `out`, `.turbo`) and `docs` (`.vitepress/cache`) and switches docs build to `npm ci --ignore-scripts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b64da9e6e6e593338320cb8775cc2794e1b297a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Expand common task commands to cover Go, chat, and docs targets

### What Changed
- Build, test, lint, and clean now run across the detected repo surfaces instead of only the root Go app
- Chat builds and linting run when the `chat` app is present, and docs build runs when the docs project is available
- Go linting now checks formatting before vetting code, and clean removes Go cache/temp files plus generated chat and docs build output
- Tasks skip missing targets and unavailable docs dependencies, so shared commands work more reliably across different checkout states

### Impact
`✅ Broader repo-wide build checks`
`✅ Fewer task failures in partial checkouts`
`✅ Cleaner local rebuilds` 


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=FIE3KdKINRZIkurPVALtw6darjmMX9n9gxJtROhS78w&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
