### PR TITLE
chore: add common taskfile coverage

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,9 +40,7 @@ tasks:
     cmds:
       - |
         bash -euo pipefail -c '
-          if [ ! -d node_modules ]; then
-            bun install --frozen-lockfile
-          fi
+          bun install --frozen-lockfile
           bun run build
         '
 
@@ -62,6 +60,7 @@ tasks:
     desc: Run tests for detected language targets ({{.DETECTED_LANGUAGES}}).
     cmds:
       - task: test:go
+      - task: test:chat
 
   test:go:
     internal: true
@@ -74,6 +73,22 @@ tasks:
           export GOTMPDIR="$PWD/{{.GO_TMP_DIR}}"
           mkdir -p "$GOCACHE" "$GOTMPDIR"
           go test -p {{.GO_PACKAGE_PARALLELISM}} -short ./...
+        '
+
+  test:chat:
+    internal: true
+    status:
+      - test ! -f package.json
+    dir: chat
+    cmds:
+      - |
+        bash -euo pipefail -c '
+          if bun run | grep -Eq "^ +test($|:)"; then
+            bun install --frozen-lockfile
+            bun run test
+          else
+            printf "No chat test script detected; skipping Bun/Node tests.\n"
+          fi
         '
 
   lint:
@@ -111,9 +126,7 @@ tasks:
     cmds:
       - |
         bash -euo pipefail -c '
-          if [ ! -d node_modules ]; then
-            bun install --frozen-lockfile
-          fi
+          bun install --frozen-lockfile
           bun run lint
         '
 


### PR DESCRIPTION
## **User description**
Add chat test coverage to the common Taskfile test target and make Bun task preflights refresh frozen dependencies before running chat build/lint scripts.

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/dev task orchestration, mainly adding a new chat test step and making Bun installs run consistently before build/lint.
> 
> **Overview**
> Adds Bun/Node coverage to the top-level `task test` by introducing `test:chat`, which conditionally runs `bun run test` when a `test` script exists.
> 
> Updates chat `build` and `lint` tasks to always run `bun install --frozen-lockfile` (instead of only when `node_modules` is missing) to ensure dependencies are refreshed before running the scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 397e605f7ec3e9797079f353df7f1f9ab492ad67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Run chat tests and refresh chat dependencies before build/lint**

### What Changed
- The shared test task now includes chat tests when a chat test script is present
- Chat build and lint now always refresh Bun dependencies before running, instead of only when dependencies are missing
- If no chat test script exists, the test step is skipped with a clear message

### Impact
`✅ Broader test coverage for chat projects`
`✅ Fewer stale-dependency build and lint failures`
`✅ Clearer test skipping when chat tests are not defined`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=NxNYXHyFW_cLSpkZMZnqVK-Thhlo9mAGl3uRXVmkWxc&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
