### PR TITLE
docs: add work-state header to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **Work state:** ACTIVE · **Progress:** `████████▌░ 85%`
+> HTTP API controlling 11 agent CLIs; single cobra binary, full endpoint set served, build green. Upkeep: huma/chat-embed CI + flaky e2e. · updated 2026-06-02
+
 # AgentAPI++ (KooshaPari Fork)
 
 Multi-model AI routing gateway extending Anthropic's agentapi — Phenotype org fork (74 commits ahead, 7 fixes staged for upstream).


### PR DESCRIPTION
Adds the org-standard work-state header (state + 10-block progress bar + focus line + date) to the top of the README, per the org-wide README work-state convention. State/percent set honestly from the dom-cli-ax coherence audit. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only metadata; no code, config, or deployment impact.
> 
> **Overview**
> Adds an org-standard **work-state** block at the top of `README.md`: **ACTIVE** status, an **85%** progress bar, a one-line focus summary (11 agent CLIs, build/endpoint health, huma/chat-embed CI and flaky e2e upkeep), and **updated 2026-06-02**.
> 
> No runtime, API, or build changes—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d5c5f46b2916982ca0ef7c4dbe2801d5228a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with project progress indicator (ACTIVE, 85%) and latest update timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->