### PR TITLE
fix(ci): resolve Go lint/gen failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+BINPATH ?= ./agentapi
+GO_CACHE_DIR ?= .cache/go-build
+GO_TMP_DIR ?= .cache/go-tmp
+GO_PACKAGE_PARALLELISM ?= 1
+
+.PHONY: lint gen build
+
+lint:
+	bash -euo pipefail -c '\
+		export GOCACHE="$(PWD)/$(GO_CACHE_DIR)" \
+		export GOTMPDIR="$(PWD)/$(GO_TMP_DIR)" && \
+		mkdir -p "$$GOCACHE" "$$GOTMPDIR" && \
+		git ls-files "*.go" ":!:agentapi-plusplus/**" | xargs gofmt -l | tee /tmp/agentapi-gofmt.out && \
+		test ! -s /tmp/agentapi-gofmt.out && \
+		go vet -p $(GO_PACKAGE_PARALLELISM) ./... \
+	'
+
+gen:
+	bash -lc '\
+		tmp_file="openapi.json.gen.tmp" && \
+		rm -f "$$tmp_file" && \
+		go run . server --print-openapi dummy > "$$tmp_file" && \
+		rm -f openapi.json && \
+		mv "$$tmp_file" openapi.json && \
+		bash ./version.sh \
+	'
+
+build:
+	task build:go GO_BINARY="$(BINPATH)"


### PR DESCRIPTION
## Summary
- Add Makefile targets to support CI commands (lint, gen, uild).
- make lint now executes Go formatting checks and go vet directly.
- make gen now executes Go CLI generation flow via bash for deterministic OpenAPI/version updates.
- make build delegates to 	ask build:go with BINPATH passthrough.
- Local validation completed with make lint and make gen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and CI wiring only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Introduces a root **Makefile** so CI and local dev can run the same Go workflows via `make lint`, `make gen`, and `make build`.
> 
> **`make lint`** runs `gofmt -l` on tracked `*.go` files (excluding `agentapi-plusplus/**`), fails on any unformatted file, then runs `go vet` with configurable cache/tmp dirs and package parallelism.
> 
> **`make gen`** regenerates `openapi.json` atomically via `go run . server --print-openapi`, then runs `./version.sh`.
> 
> **`make build`** delegates to `task build:go` with `BINPATH` defaulting to `./agentapi`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d084ad57136289c50e43ffd1b9aaa741d7458bbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->