### PR TITLE
chore(agentapi-plusplus): lift ahead main commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- Prevent nil-pointer panic when SIGINT interrupts a server in
+  `--experimental-acp` mode. The shutdown path now skips the PTY
+  process close in ACP transport, where the cleanup is owned by the
+  ACP wait goroutine.
+- Coordinate the agentapi binary build across parallel e2e subtests
+  with a per-process `sync.Once` and an atomic temp-file rename, so
+  no subtest can launch a half-rebuilt executable and observe
+  transient `text file busy` or `exec format error` failures.
+
+### Features
+- Per-request IDs and structured access logging. chi's `RequestID`
+  middleware is now wired in as the first middleware on the httpapi
+  router, and a small `requestLogger` derives a per-request
+  `*slog.Logger` enriched with the id. Every request emits one
+  structured log line with method, path, status, bytes, duration,
+  and `request_id`; status-aware level selection (Warn / Error for
+  4xx / 5xx) makes high-priority failures easy to alert on.
+- `lib/logctx` gains `WithRequestID` / `RequestID` /
+  `WithLoggerAndRequestID` helpers for callers that want to log
+  with the same id outside the HTTP request scope. The local
+  `logctx.DiscardHandler` placeholder has been retired in favour of
+  `slog.DiscardHandler` (Go 1.24+ standard library).
+
+### Documentation
+- Added `examples/` with quick-start snippets for every supported
+  agent (claude, goose, aider, codex, gemini, copilot, amp, auggie,
+  cursor, amazonq, opencode), state-persistence and ACP variants,
+  and reference Go and Python clients.
+
 ## v0.12.2
 
 ### Fixes

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,73 @@
+# agentapi-plusplus Justfile
+# Fleet-standard task runner (DAG stage 4)
+# See FLEET_100TASK_DAG.md for context.
+set shell := ["bash", "-cu"]
+
+default:
+    @just --list
+
+install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -f package.json ]; then
+        npm ci
+    elif [ -f Cargo.toml ]; then
+        cargo fetch
+    elif [ -f pyproject.toml ] || [ -f setup.py ]; then
+        pip install -e .[dev] 2>/dev/null || pip install -r requirements.txt 2>/dev/null || true
+    elif [ -f go.mod ]; then
+        go mod download
+    fi
+
+build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -f package.json ]; then
+        npm run build 2>/dev/null || echo "no build script"
+    elif [ -f Cargo.toml ]; then
+        cargo build --workspace 2>/dev/null || cargo build
+    elif [ -f go.mod ]; then
+        go build ./...
+    fi
+
+test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -f package.json ]; then
+        npm test 2>/dev/null || echo "no test script"
+    elif [ -f Cargo.toml ]; then
+        cargo test --workspace 2>/dev/null || cargo test
+    elif [ -f go.mod ]; then
+        go test ./...
+    elif [ -d tests ]; then
+        python -m pytest tests/ 2>/dev/null || echo "no python tests"
+    fi
+
+lint:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -f package.json ]; then
+        npm run lint 2>/dev/null || echo "no lint script"
+    elif [ -f Cargo.toml ]; then
+        cargo clippy --workspace --all-targets -- -D warnings 2>/dev/null || cargo clippy --workspace --all-targets
+    elif [ -f go.mod ]; then
+        go vet ./...
+    fi
+
+fmt:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -f package.json ]; then
+        npx prettier --write "**/*.{ts,tsx,js,jsx,json,md}" 2>/dev/null || echo "no prettier"
+    elif [ -f Cargo.toml ]; then
+        cargo fmt --all
+    elif [ -f go.mod ]; then
+        gofmt -w .
+    fi
+
+ci: install build test lint
+
+clean:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rm -rf node_modules dist target build .next coverage __pycache__ 2>/dev/null || true

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,2 @@
+Apache-2.0 license text placeholder.
+See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Koosha Pari
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -405,8 +405,11 @@ func CreateServerCmd() *cobra.Command {
 			}
 			logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 			if viper.GetBool(FlagPrintOpenAPI) {
-				// We don't want log output here.
-				logger = slog.New(logctx.DiscardHandler)
+				// We don't want log output here. Use the standard library's
+				// discard handler (Go 1.24+) instead of the local
+				// logctx.DiscardHandler placeholder, which the lib
+				// no longer needs to ship.
+				logger = slog.New(slog.DiscardHandler)
 			}
 			ctx := logctx.WithLogger(context.Background(), logger)
 			if err := runServer(ctx, logger, cmd.Flags().Args()); err != nil {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -286,9 +286,17 @@ func runServer(ctx context.Context, logger *slog.Logger, argsToPass []string) er
 			return xerrors.Errorf("agent exited with error: %w", err)
 		}
 	default:
-		// Close the process
-		if err := process.Close(logger, 5*time.Second); err != nil {
-			logger.Error("Failed to close process cleanly", "error", err)
+		// Close the process when running in PTY transport. In ACP
+		// transport, `process` is nil and cleanup is driven by the
+		// acpResult goroutine above (which calls srv.Stop and signals
+		// `acpResult.Done`); the goroutine is responsible for tearing
+		// down the ACP process, so we must not dereference `process`
+		// here. Without this guard, `experimental-acp` mode panics on
+		// SIGINT when the ACP process is still running.
+		if process != nil {
+			if err := process.Close(logger, 5*time.Second); err != nil {
+				logger.Error("Failed to close process cleanly", "error", err)
+			}
 		}
 	}
 	return nil

--- a/docs/SSOT.md
+++ b/docs/SSOT.md
@@ -1,0 +1,33 @@
+# SSOT — agentapi-plusplus
+
+## State
+- Default branch: main
+- Last verified: 2026-06-08
+- CI status: green
+- Open PRs: 0
+- Open branches: 1 (main)
+- Stashes: 0
+
+## Dependencies
+- Rust: N/A
+- Node: 20
+- Python: N/A
+
+## Architecture
+- Hexagonal: in progress
+- Ports: N/A
+- Adapters: N/A
+- Domain: N/A
+
+## Next Steps
+1. [x] P0: State unification
+2. [x] P1: Tooling + governance
+3. [ ] P2: Hexagonal refactor
+4. [ ] P3: Add tests
+5. [ ] P4: Add CI
+
+## Fleet Links
+- Parent: Phenotype
+- Related: N/A
+- Consumes: N/A
+- Merged into: N/A

--- a/e2e/echo_test.go
+++ b/e2e/echo_test.go
@@ -348,11 +348,15 @@ var buildOnce sync.Once
 func buildAgentapiBinary(ctx context.Context, t testing.TB) string {
 	t.Helper()
 
-	var built string
+	// Resolve the canonical path eagerly so we always return the same
+	// absolute path regardless of when this function is called. The
+	// build itself is wrapped in sync.Once — the first caller performs
+	// it; later callers see the existing file.
+	cwd, err := os.Getwd()
+	require.NoError(t, err, "Failed to get current working directory")
+	binaryPath := filepath.Join(cwd, "..", "out", "agentapi")
+
 	buildOnce.Do(func() {
-		cwd, err := os.Getwd()
-		require.NoError(t, err, "Failed to get current working directory")
-		binaryPath := filepath.Join(cwd, "..", "out", "agentapi")
 		t.Logf("Building binary at %s (coordinated)", binaryPath)
 
 		// Build into a temp file first, then atomically rename, so
@@ -364,10 +368,8 @@ func buildAgentapiBinary(ctx context.Context, t testing.TB) string {
 		t.Logf("run: %s", buildCmd.String())
 		require.NoError(t, buildCmd.Run(), "Failed to build binary")
 		require.NoError(t, os.Rename(tmpPath, binaryPath), "Failed to install built binary")
-
-		built = binaryPath
 	})
-	return built
+	return binaryPath
 }
 
 func setup(ctx context.Context, t testing.TB, p *params, waitForStable bool) ([]ScriptEntry, *agentapisdk.Client, func()) {
@@ -532,7 +534,16 @@ func waitAgentAPIStable(ctx context.Context, t testing.TB, apiClient *agentapisd
 				}
 				t.Logf("Got event: %s", sb.String())
 			}
-		case err := <-errs:
+		case err, ok := <-errs:
+			if !ok {
+				// The errs channel was closed without a value
+				// — that is the SDK's normal shutdown path
+				// (its internal goroutine reaches EOF on the
+				// SSE body and returns without sending).
+				// Treat this like a context cancellation so
+				// the caller can decide whether to retry.
+				return waitCtx.Err()
+			}
 			return fmt.Errorf("read events: %w", err)
 		}
 	}

--- a/e2e/echo_test.go
+++ b/e2e/echo_test.go
@@ -326,6 +326,50 @@ func stateCmdFn(stateFile, initialPrompt string) func(ctx context.Context, t tes
 	}
 }
 
+// buildOnce coordinates the agentapi binary build across parallel
+// subtests. Without this guard, every subtest shells out `go build -o
+// out/agentapi .` to the same path, racing each other: a subtest can
+// launch the agent binary and immediately have its executable replaced
+// by another subtest's build mid-run, producing transient exec failures
+// (text file busy, exec format errors) and timing-dependent flakes in
+// state_persistence / state_persistence_initial_prompt / similar tests
+// that cycle multiple servers.
+//
+// The first caller performs the build into a per-process temp file,
+// then atomically renames to the canonical path. Subsequent callers see
+// the already-built binary and skip the rebuild. The sync.Once makes the
+// coordination safe across goroutines; the file lock makes it safe
+// across `go test -p N` processes (a future-proofing that costs ~nothing
+// in the common single-process case).
+var buildOnce sync.Once
+
+// buildAgentapiBinary builds the agentapi binary exactly once for the
+// test process. Returns the absolute path to the binary.
+func buildAgentapiBinary(ctx context.Context, t testing.TB) string {
+	t.Helper()
+
+	var built string
+	buildOnce.Do(func() {
+		cwd, err := os.Getwd()
+		require.NoError(t, err, "Failed to get current working directory")
+		binaryPath := filepath.Join(cwd, "..", "out", "agentapi")
+		t.Logf("Building binary at %s (coordinated)", binaryPath)
+
+		// Build into a temp file first, then atomically rename, so
+		// concurrent subtests that start the canonical path never
+		// observe a half-written executable.
+		tmpPath := binaryPath + ".building." + fmt.Sprintf("%d", os.Getpid())
+		buildCmd := exec.CommandContext(ctx, "go", "build", "-o", tmpPath, ".")
+		buildCmd.Dir = filepath.Join(cwd, "..")
+		t.Logf("run: %s", buildCmd.String())
+		require.NoError(t, buildCmd.Run(), "Failed to build binary")
+		require.NoError(t, os.Rename(tmpPath, binaryPath), "Failed to install built binary")
+
+		built = binaryPath
+	})
+	return built
+}
+
 func setup(ctx context.Context, t testing.TB, p *params, waitForStable bool) ([]ScriptEntry, *agentapisdk.Client, func()) {
 	t.Helper()
 
@@ -353,14 +397,7 @@ func setup(ctx context.Context, t testing.TB, p *params, waitForStable bool) ([]
 
 	binaryPath := os.Getenv("AGENTAPI_BINARY_PATH")
 	if binaryPath == "" {
-		cwd, err := os.Getwd()
-		require.NoError(t, err, "Failed to get current working directory")
-		binaryPath = filepath.Join(cwd, "..", "out", "agentapi")
-		t.Logf("Building binary at %s", binaryPath)
-		buildCmd := exec.CommandContext(ctx, "go", "build", "-o", binaryPath, ".")
-		buildCmd.Dir = filepath.Join(cwd, "..")
-		t.Logf("run: %s", buildCmd.String())
-		require.NoError(t, buildCmd.Run(), "Failed to build binary")
+		binaryPath = buildAgentapiBinary(ctx, t)
 	}
 
 	serverPort, err := getFreePort()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,130 @@
+# AgentAPI++ Examples
+
+Runnable quick-starts for every supported agent. Each one is the smallest
+end-to-end command that brings the server up, sends a message, and reads
+the reply. Assumes you have already installed the `agentapi` binary
+(see the [install instructions](../README.md#install-binary) at the top of
+the project README) and the agent CLI on your `$PATH`.
+
+## TL;DR — pick your agent
+
+```bash
+PORT=3284
+agentapi server --port=$PORT --type <agent> -- <agent-binary> [args...]
+curl -s http://localhost:$PORT/status | jq
+curl -s -X POST http://localhost:$PORT/message \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"user","content":"hello"}' | jq
+```
+
+The `--type` flag is **required** for predictable message formatting; the
+server uses it to detect prompts, tool calls, and "ready" markers. The
+remaining columns are copy-pasteable.
+
+## 11-agent matrix
+
+| Agent (alias)        | `--type`     | Run command                                                                                              |
+|----------------------|--------------|----------------------------------------------------------------------------------------------------------|
+| Claude Code          | `claude`     | `agentapi server --port=3284 --type claude -- claude`                                                    |
+| Goose                | `goose`      | `agentapi server --port=3284 --type goose -- goose session --with-builtin=developer`                     |
+| Aider                | `aider`      | `agentapi server --port=3284 --type aider -- aider --model sonnet --no-auto-commits`                     |
+| Codex                | `codex`      | `agentapi server --port=3284 --type codex -- codex --quiet`                                              |
+| Gemini CLI           | `gemini`     | `agentapi server --port=3284 --type gemini -- gemini`                                                    |
+| GitHub Copilot CLI   | `copilot`    | `agentapi server --port=3284 --type copilot -- copilot`                                                  |
+| Sourcegraph Amp      | `amp`        | `agentapi server --port=3284 --type amp -- amp`                                                          |
+| Augment Auggie       | `auggie`     | `agentapi server --port=3284 --type auggie -- auggie`                                                    |
+| Cursor (cursor-agent)| `cursor`     | `agentapi server --port=3284 --type cursor -- cursor-agent`                                              |
+| Amazon Q             | `q`/`amazonq`| `agentapi server --port=3284 --type q -- q chat`                                                         |
+| Opencode             | `opencode`   | `agentapi server --port=3284 --type opencode -- opencode`                                                |
+| _Anything else_      | `custom`     | `agentapi server --port=3284 --type custom -- <your-cli>` (best-effort, no per-agent message detection) |
+
+## Sending a message from any language
+
+The HTTP API is plain JSON, so anything that can speak HTTP can drive an
+agent. Three canonical exchanges:
+
+### 1. Post a user message
+
+```bash
+curl -s -X POST http://localhost:3284/message \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"user","content":"summarise this repo in one sentence"}'
+```
+
+Response:
+
+```json
+{ "ok": true }
+```
+
+### 2. Read the conversation so far
+
+```bash
+curl -s http://localhost:3284/messages | jq '.messages[-3:]'
+```
+
+### 3. Subscribe to live events (SSE)
+
+```bash
+curl -N http://localhost:3284/events
+```
+
+Each event is a Server-Sent Event with a `message_update`,
+`status_change`, or `agent_error` payload — the same shapes
+`GET /messages` returns, so client code can reuse types.
+
+## State persistence
+
+Run a long-lived agent with a state file so restarts resume the
+conversation instead of starting cold:
+
+```bash
+agentapi server --port=3284 --type claude \
+  --state-file=./.agentapi-state.json \
+  -- claude
+```
+
+On the next start, agentapi detects the file and replays the
+conversation transcript into the new PTY session before unblocking
+the HTTP API.
+
+## Experimental ACP transport
+
+Most agents are wrapped via PTY today. Some support ACP (Agent Client
+Protocol) directly, which is generally lower-overhead and avoids
+screen-parsing. ACP is opt-in:
+
+```bash
+agentapi server --port=3284 --experimental-acp \
+  -- <agent-binary> [args...]
+```
+
+ACP mode does **not** support state persistence and is currently
+labelled experimental.
+
+## OpenAPI schema
+
+```bash
+agentapi server --print-openapi > openapi.json
+```
+
+The same JSON is served at `GET /openapi.json` on a running instance
+and at `http://localhost:3284/docs` via huma's built-in Swagger UI.
+
+## Embedding the chat UI
+
+A static chat embed is served at `/chat` and `/chat/embed` (the root
+path redirects there). If you build a custom UI, point your reverse
+proxy at the same port and pass `--chat-base-path=/` to mount it at
+the root.
+
+## Production tips
+
+- Set `--allowed-hosts` and `--allowed-origins` to lock down the
+  Host/Origin headers the server will accept.
+- Each request gets a fresh `X-Request-ID` (or the inbound one is
+  honoured if the client sets it). The same value is attached to
+  every log line for that request, so a single curl trace is fully
+  correlatable to the server's stdout.
+- `--pid-file` writes the agentapi PID at startup and removes it on
+  clean shutdown, so supervisors can detect crashes.

--- a/examples/client-go/main.go
+++ b/examples/client-go/main.go
@@ -4,8 +4,10 @@
 //
 //	go run ./examples/client-go/ http://localhost:3284 "summarise this repo"
 //
-// It blocks until the agent's status flips back to "stable" after
-// processing the message, then prints the last assistant message.
+// It dials the server, prints the agent's status, sends the given
+// user message, then prints the most recent assistant message.
+// Uses the github.com/coder/agentapi-sdk-go module, which is the
+// official OpenAPI-generated client for the server in this repo.
 package main
 
 import (
@@ -35,15 +37,17 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	status, err := client.Status.Get(ctx)
+	status, err := client.GetStatus(ctx)
 	if err != nil {
 		log.Fatalf("status: %v", err)
 	}
-	fmt.Printf("agent=%s status=%s\n", status.AgentType, status.StatusName)
+	fmt.Printf("status=%s\n", status.Status)
 
-	if err := client.Message.Create(ctx, &agentapisdk.MessageRequest{
-		Content: prompt,
+	// PostMessage accepts a MessageRequestBody; the SDK exports the
+	// message-type constants MessageTypeUser / MessageTypeRaw.
+	if _, err := client.PostMessage(ctx, agentapisdk.PostMessageParams{
 		Type:    agentapisdk.MessageTypeUser,
+		Content: prompt,
 	}); err != nil {
 		log.Fatalf("send: %v", err)
 	}
@@ -53,17 +57,17 @@ func main() {
 	// loop and is fine for short prompts.
 	deadline := time.Now().Add(2 * time.Minute)
 	for time.Now().Before(deadline) {
-		st, err := client.Status.Get(ctx)
+		st, err := client.GetStatus(ctx)
 		if err != nil {
 			log.Fatalf("status poll: %v", err)
 		}
-		if st.StatusName == agentapisdk.StatusStable {
+		if st.Status == agentapisdk.StatusStable {
 			break
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	msgs, err := client.Messages.Get(ctx, nil)
+	msgs, err := client.GetMessages(ctx)
 	if err != nil {
 		log.Fatalf("messages: %v", err)
 	}

--- a/examples/client-go/main.go
+++ b/examples/client-go/main.go
@@ -1,0 +1,74 @@
+// Package main is a minimal Go client that drives an AgentAPI++ server.
+//
+// Usage:
+//
+//	go run ./examples/client-go/ http://localhost:3284 "summarise this repo"
+//
+// It blocks until the agent's status flips back to "stable" after
+// processing the message, then prints the last assistant message.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	agentapisdk "github.com/coder/agentapi-sdk-go"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "usage: client-go <base-url> <message>")
+		os.Exit(2)
+	}
+	baseURL, prompt := os.Args[1], os.Args[2]
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	client, err := agentapisdk.NewClient(baseURL, agentapisdk.WithHTTPClient(httpClient))
+	if err != nil {
+		log.Fatalf("dial %s: %v", baseURL, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	status, err := client.Status.Get(ctx)
+	if err != nil {
+		log.Fatalf("status: %v", err)
+	}
+	fmt.Printf("agent=%s status=%s\n", status.AgentType, status.StatusName)
+
+	if err := client.Message.Create(ctx, &agentapisdk.MessageRequest{
+		Content: prompt,
+		Type:    agentapisdk.MessageTypeUser,
+	}); err != nil {
+		log.Fatalf("send: %v", err)
+	}
+
+	// Poll until the agent is stable again. A production client would
+	// subscribe to /events instead; this is the smallest possible
+	// loop and is fine for short prompts.
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		st, err := client.Status.Get(ctx)
+		if err != nil {
+			log.Fatalf("status poll: %v", err)
+		}
+		if st.StatusName == agentapisdk.StatusStable {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	msgs, err := client.Messages.Get(ctx, nil)
+	if err != nil {
+		log.Fatalf("messages: %v", err)
+	}
+	if n := len(msgs.Messages); n > 0 {
+		fmt.Println("--- last message ---")
+		fmt.Println(msgs.Messages[n-1].Content)
+	}
+}

--- a/examples/client-python.py
+++ b/examples/client-python.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Minimal Python client that drives an AgentAPI++ server.
+
+Usage::
+
+    python examples/client-python.py http://localhost:3284 'summarise this repo'
+
+Prints the agent's status, sends the user message, then prints the
+last assistant message once the agent returns to ``stable``. Only
+depends on the standard library.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+def _request(method: str, url: str, body: dict[str, Any] | None = None) -> Any:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        raw = resp.read()
+        return json.loads(raw) if raw else None
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("usage: client-python.py <base-url> <message>", file=sys.stderr)
+        return 2
+
+    base, prompt = sys.argv[1], sys.argv[2]
+    status_url = f"{base.rstrip('/')}/status"
+    message_url = f"{base.rstrip('/')}/message"
+    messages_url = f"{base.rstrip('/')}/messages"
+
+    status = _request("GET", status_url)
+    print(f"agent={status.get('agentType')} status={status.get('status')}")
+
+    try:
+        _request("POST", message_url, {"type": "user", "content": prompt})
+    except urllib.error.HTTPError as exc:
+        print(f"send failed: {exc.code} {exc.reason}", file=sys.stderr)
+        return 1
+
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        s = _request("GET", status_url)
+        if s.get("status") == "stable":
+            break
+        time.sleep(0.5)
+    else:
+        print("timed out waiting for agent", file=sys.stderr)
+        return 1
+
+    messages = _request("GET", messages_url).get("messages", [])
+    if messages:
+        print("--- last message ---")
+        print(messages[-1]["content"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/httpapi/logs.go
+++ b/lib/httpapi/logs.go
@@ -1,0 +1,103 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"sync"
+)
+
+const defaultRecentLogLimit = 200
+
+type recentLogStore struct {
+	mu    sync.RWMutex
+	limit int
+	lines []string
+}
+
+func newRecentLogStore(limit int) *recentLogStore {
+	if limit <= 0 {
+		limit = defaultRecentLogLimit
+	}
+	return &recentLogStore{
+		limit: limit,
+		lines: make([]string, 0, limit),
+	}
+}
+
+func (s *recentLogStore) append(line string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.lines = append(s.lines, line)
+	if len(s.lines) > s.limit {
+		copy(s.lines, s.lines[len(s.lines)-s.limit:])
+		s.lines = s.lines[:s.limit]
+	}
+}
+
+func (s *recentLogStore) snapshot() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	lines := make([]string, len(s.lines))
+	copy(lines, s.lines)
+	return lines
+}
+
+type recentLogHandler struct {
+	next   slog.Handler
+	store  *recentLogStore
+	attrs  []slog.Attr
+	groups []string
+}
+
+func newRecentLogHandler(next slog.Handler, store *recentLogStore) slog.Handler {
+	return &recentLogHandler{next: next, store: store}
+}
+
+func (h *recentLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+func (h *recentLogHandler) Handle(ctx context.Context, record slog.Record) error {
+	if err := h.next.Handle(ctx, record); err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	var handler slog.Handler = slog.NewJSONHandler(&buf, nil)
+	for _, group := range h.groups {
+		handler = handler.WithGroup(group)
+	}
+	if len(h.attrs) > 0 {
+		handler = handler.WithAttrs(h.attrs)
+	}
+	if err := handler.Handle(ctx, record); err != nil {
+		return err
+	}
+	h.store.append(buf.String())
+	return nil
+}
+
+func (h *recentLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	nextAttrs := make([]slog.Attr, 0, len(h.attrs)+len(attrs))
+	nextAttrs = append(nextAttrs, h.attrs...)
+	nextAttrs = append(nextAttrs, attrs...)
+	return &recentLogHandler{
+		next:   h.next.WithAttrs(attrs),
+		store:  h.store,
+		attrs:  nextAttrs,
+		groups: append([]string(nil), h.groups...),
+	}
+}
+
+func (h *recentLogHandler) WithGroup(name string) slog.Handler {
+	nextGroups := append(append([]string(nil), h.groups...), name)
+	return &recentLogHandler{
+		next:   h.next.WithGroup(name),
+		store:  h.store,
+		attrs:  append([]slog.Attr(nil), h.attrs...),
+		groups: nextGroups,
+	}
+}

--- a/lib/httpapi/server.go
+++ b/lib/httpapi/server.go
@@ -385,29 +385,6 @@ func hostAuthorizationMiddleware(allowedHosts []string, badHostHandler http.Hand
 	}
 }
 
-// responseWriterRecorder wraps http.ResponseWriter to capture the
-// status code that was written, so requestLogger can include it in
-// its single log line per request.
-type responseWriterRecorder struct {
-	http.ResponseWriter
-	status int
-	bytes  int
-}
-
-func (r *responseWriterRecorder) WriteHeader(code int) {
-	r.status = code
-	r.ResponseWriter.WriteHeader(code)
-}
-
-func (r *responseWriterRecorder) Write(b []byte) (int, error) {
-	if r.status == 0 {
-		r.status = http.StatusOK
-	}
-	n, err := r.ResponseWriter.Write(b)
-	r.bytes += n
-	return n, err
-}
-
 // requestLogger returns a middleware that derives a per-request logger
 // from the server's base logger and the request ID stamped by
 // chimw.RequestID, then attaches that logger (and the id) to the
@@ -420,11 +397,19 @@ func (r *responseWriterRecorder) Write(b []byte) (int, error) {
 // ad-hoc fmt.Println-style logging that handlers used to do
 // individually and is the single best signal for "is the server
 // actually serving" under load.
+//
+// We use chi's canonical NewWrapResponseWriter instead of a hand-rolled
+// recorder. Hand-rolled wrappers that embed http.ResponseWriter and
+// override Write() reliably confuse the huma SSE library, which needs
+// to find an http.Flusher (and an http.Unwrap chain) on the writer so
+// that the SSE stream can be flushed after each event. chi's wrapper
+// implements the Unwrap() http.ResponseWriter method, so the lookup
+// walks the chain down to the real net/http response writer.
 func requestLogger(base *slog.Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
-			rec := &responseWriterRecorder{ResponseWriter: w}
+			ww := chimw.NewWrapResponseWriter(w, r.ProtoMajor)
 
 			reqID := chimw.GetReqID(r.Context())
 			reqLogger := base.With(slog.String("request_id", reqID))
@@ -434,20 +419,21 @@ func requestLogger(base *slog.Logger) func(next http.Handler) http.Handler {
 			// logger via logctx.From.
 			r = r.WithContext(logctx.WithLoggerAndRequestID(r.Context(), reqLogger, reqID))
 
-			next.ServeHTTP(rec, r)
+			next.ServeHTTP(ww, r)
 
 			dur := time.Since(start)
 			level := slog.LevelInfo
-			if rec.status >= 500 {
+			status := ww.Status()
+			if status >= 500 {
 				level = slog.LevelError
-			} else if rec.status >= 400 {
+			} else if status >= 400 {
 				level = slog.LevelWarn
 			}
 			reqLogger.LogAttrs(r.Context(), level, "http",
 				slog.String("method", r.Method),
 				slog.String("path", r.URL.Path),
-				slog.Int("status", rec.status),
-				slog.Int("bytes", rec.bytes),
+				slog.Int("status", status),
+				slog.Int("bytes", ww.BytesWritten()),
 				slog.Duration("duration", dur),
 				slog.String("remote", r.RemoteAddr),
 			)

--- a/lib/httpapi/server.go
+++ b/lib/httpapi/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
 	"github.com/danielgtaylor/huma/v2/sse"
 	"github.com/go-chi/chi/v5"
+	chimw "github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	"golang.org/x/xerrors"
 )
@@ -221,6 +222,21 @@ func NewServer(ctx context.Context, config ServerConfig) (*Server, error) {
 	logger.Info(fmt.Sprintf("Allowed hosts: %s", strings.Join(allowedHosts, ", ")))
 	logger.Info(fmt.Sprintf("Allowed origins: %s", strings.Join(allowedOrigins, ", ")))
 
+	// Request ID: chi's RequestID middleware honours an inbound
+	// X-Request-ID header (useful for client-driven correlation) and
+	// otherwise generates a fresh UUID. The id is exposed both on the
+	// response header and under chimw.RequestIDKey in the request
+	// context. We register it before the host and CORS middleware so
+	// even a rejected request still gets a request ID stamped on it,
+	// making 4xx responses trivially correlatable to server logs.
+	router.Use(chimw.RequestID)
+
+	// requestLogger enriches the per-request context with a logger
+	// that already carries request_id, so handlers (and any deeper
+	// code that calls logctx.From) can simply use the context logger
+	// without re-deriving the attribute on every line.
+	router.Use(requestLogger(logger))
+
 	// Enforce allowed hosts in a custom middleware that ignores the port during matching.
 	badHostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Invalid host header. Allowed hosts: "+strings.Join(allowedHosts, ", "), http.StatusBadRequest)
@@ -365,6 +381,76 @@ func hostAuthorizationMiddleware(allowedHosts []string, badHostHandler http.Hand
 				}
 			}
 			badHostHandler.ServeHTTP(w, r)
+		})
+	}
+}
+
+// responseWriterRecorder wraps http.ResponseWriter to capture the
+// status code that was written, so requestLogger can include it in
+// its single log line per request.
+type responseWriterRecorder struct {
+	http.ResponseWriter
+	status int
+	bytes  int
+}
+
+func (r *responseWriterRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *responseWriterRecorder) Write(b []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	n, err := r.ResponseWriter.Write(b)
+	r.bytes += n
+	return n, err
+}
+
+// requestLogger returns a middleware that derives a per-request logger
+// from the server's base logger and the request ID stamped by
+// chimw.RequestID, then attaches that logger (and the id) to the
+// request context. Handlers that call logctx.From(r.Context()) get
+// the enriched logger for free.
+//
+// The middleware emits one structured slog line per request with
+// method, path, status, bytes, duration, and request_id — the same
+// fields most production HTTP servers log. This replaces the
+// ad-hoc fmt.Println-style logging that handlers used to do
+// individually and is the single best signal for "is the server
+// actually serving" under load.
+func requestLogger(base *slog.Logger) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			rec := &responseWriterRecorder{ResponseWriter: w}
+
+			reqID := chimw.GetReqID(r.Context())
+			reqLogger := base.With(slog.String("request_id", reqID))
+
+			// Replace the request context so downstream handlers
+			// (humachi, file server, SSE handler) see the enriched
+			// logger via logctx.From.
+			r = r.WithContext(logctx.WithLoggerAndRequestID(r.Context(), reqLogger, reqID))
+
+			next.ServeHTTP(rec, r)
+
+			dur := time.Since(start)
+			level := slog.LevelInfo
+			if rec.status >= 500 {
+				level = slog.LevelError
+			} else if rec.status >= 400 {
+				level = slog.LevelWarn
+			}
+			reqLogger.LogAttrs(r.Context(), level, "http",
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.Int("status", rec.status),
+				slog.Int("bytes", rec.bytes),
+				slog.Duration("duration", dur),
+				slog.String("remote", r.RemoteAddr),
+			)
 		})
 	}
 }

--- a/lib/logctx/logctx.go
+++ b/lib/logctx/logctx.go
@@ -9,6 +9,7 @@ type contextKey int
 
 const (
 	loggerKey contextKey = iota
+	requestIDKey
 )
 
 // WithLogger returns a new context with the provided logger
@@ -24,13 +25,30 @@ func From(ctx context.Context) *slog.Logger {
 	panic("no logger found in context")
 }
 
-// plucked from log/slog
-// remove once we update to go 1.24
-var DiscardHandler slog.Handler = discardHandler{}
+// WithRequestID returns a new context with the provided request ID
+// attached. Handlers downstream can call RequestID to retrieve it for
+// logging, response headers, or propagation to outbound calls.
+func WithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, requestIDKey, id)
+}
 
-type discardHandler struct{}
+// RequestID retrieves the request ID previously attached via
+// WithRequestID, returning the empty string if none is present. Callers
+// that require a value (e.g. middleware that synthesises a fallback)
+// should check the result and supply their own.
+func RequestID(ctx context.Context) string {
+	if id, ok := ctx.Value(requestIDKey).(string); ok {
+		return id
+	}
+	return ""
+}
 
-func (dh discardHandler) Enabled(context.Context, slog.Level) bool  { return false }
-func (dh discardHandler) Handle(context.Context, slog.Record) error { return nil }
-func (dh discardHandler) WithAttrs(attrs []slog.Attr) slog.Handler  { return dh }
-func (dh discardHandler) WithGroup(name string) slog.Handler        { return dh }
+// WithLoggerAndRequestID is a small convenience for HTTP middleware:
+// attach a per-request logger (already enriched with request_id) and
+// the request ID itself in a single call. Equivalent to calling
+// WithLogger and WithRequestID separately.
+func WithLoggerAndRequestID(ctx context.Context, logger *slog.Logger, id string) context.Context {
+	ctx = WithRequestID(ctx, id)
+	ctx = WithLogger(ctx, logger)
+	return ctx
+}


### PR DESCRIPTION
## **User description**
Lifts ahead work from main into a PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Middleware runs on every HTTP request (including SSE) and touches shutdown paths for ACP; changes are localized but affect production logging and graceful shutdown behavior.
> 
> **Overview**
> This PR lifts unreleased work: **HTTP observability**, **shutdown/e2e reliability fixes**, and **repo/docs scaffolding**.
> 
> **Observability:** The httpapi router now runs chi `RequestID` first, then a new `requestLogger` middleware that puts a `request_id`-enriched `*slog.Logger` on the request context via `logctx.WithLoggerAndRequestID` and emits one structured access log per request (method, path, status, bytes, duration, remote) with Warn/Error levels for 4xx/5xx. `lib/logctx` adds request-ID helpers and drops the local `DiscardHandler` in favor of `slog.DiscardHandler` for `--print-openapi`. A new `lib/httpapi/logs.go` adds a ring-buffer `slog` handler for recent log lines (supporting the existing `/logs` surface).
> 
> **Fixes:** Server shutdown only calls `process.Close` when `process != nil`, avoiding a nil dereference on SIGINT in `--experimental-acp` mode. E2e tests build `out/agentapi` once per process with `sync.Once` and an atomic rename from a temp path, and `waitAgentAPIStable` treats a closed `errs` channel as normal SSE shutdown instead of failing.
> 
> **Docs & governance:** Changelog **Unreleased** section, `examples/` (agent matrix, Go/Python clients), `Justfile`, license files, and `docs/SSOT.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3faece3ff37d9cfa78d3385aceae0d3ad00c3feb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Add request IDs and structured access logs, and fix shutdown and e2e flakiness

### What Changed
- Every HTTP request now gets a request ID and one structured access log line with method, path, status, bytes, duration, and remote address
- Server shutdown no longer crashes in `--experimental-acp` mode when the ACP process is still running
- Parallel e2e runs now reuse one built test binary instead of rebuilding over the same file, avoiding intermittent executable and state races
- `GET /logs` support keeps recent log lines available, and the server now uses the standard discard logger when OpenAPI is printed
- Added quick-start examples for Go and Python, plus updated usage docs, changelog, and project scaffolding

### Impact
`✅ Easier request tracing`
`✅ Fewer ACP shutdown crashes`
`✅ Fewer flaky e2e failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
