### PR TITLE
fix(smoke): H9 gateway smoke — httpapi repair + ACP ClearMessages

### DIFF
--- a/lib/httpapi/server.go
+++ b/lib/httpapi/server.go
@@ -2,16 +2,23 @@ package httpapi
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/coder/agentapi/internal/version"
 	"github.com/coder/agentapi/lib/logctx"
@@ -110,7 +117,87 @@ type ServerConfig struct {
 
 // Validate allowed hosts don't contain whitespace, commas, schemes, or ports.
 // Viper/Cobra use different separators (space for env vars, comma for flags),
+// so these characters likely indicate user error.
+func parseAllowedHosts(input []string) ([]string, error) {
+	if len(input) == 0 {
+		return nil, fmt.Errorf("the list must not be empty")
+	}
+	if slices.Contains(input, "*") {
+		return []string{"*"}, nil
+	}
+	// First pass: whitespace & comma checks (surface these errors first)
+	// Viper/Cobra use different separators (space for env vars, comma for flags),
+	// so these characters likely indicate user error.
+	for _, item := range input {
+		for _, r := range item {
+			if unicode.IsSpace(r) {
+				return nil, fmt.Errorf("'%s' contains whitespace characters, which are not allowed", item)
+			}
+		}
+		if strings.Contains(item, ",") {
+			return nil, fmt.Errorf("'%s' contains comma characters, which are not allowed", item)
+		}
+	}
+	// Second pass: scheme check
+	for _, item := range input {
+		if strings.Contains(item, "http://") || strings.Contains(item, "https://") {
+			return nil, fmt.Errorf("'%s' must not include http:// or https://", item)
+		}
+	}
+	hosts := make([]*url.URL, 0, len(input))
+	// Third pass: url parse
+	for _, item := range input {
+		trimmed := strings.TrimSpace(item)
+		u, err := url.Parse("http://" + trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("'%s' is not a valid host: %w", item, err)
+		}
+		hosts = append(hosts, u)
+	}
+	// Fourth pass: port check
+	for _, u := range hosts {
+		if u.Port() != "" {
+			return nil, fmt.Errorf("'%s' must not include a port", u.Host)
+		}
+	}
+	hostStrings := make([]string, 0, len(hosts))
+	for _, u := range hosts {
+		hostStrings = append(hostStrings, u.Hostname())
+	}
+	return hostStrings, nil
+}
 
+// Validate allowed origins
+func parseAllowedOrigins(input []string) ([]string, error) {
+	if len(input) == 0 {
+		return nil, fmt.Errorf("the list must not be empty")
+	}
+	if slices.Contains(input, "*") {
+		return []string{"*"}, nil
+	}
+	// Viper/Cobra use different separators (space for env vars, comma for flags),
+	// so these characters likely indicate user error.
+	for _, item := range input {
+		for _, r := range item {
+			if unicode.IsSpace(r) {
+				return nil, fmt.Errorf("'%s' contains whitespace characters, which are not allowed", item)
+			}
+		}
+		if strings.Contains(item, ",") {
+			return nil, fmt.Errorf("'%s' contains comma characters, which are not allowed", item)
+		}
+	}
+	origins := make([]string, 0, len(input))
+	for _, item := range input {
+		trimmed := strings.TrimSpace(item)
+		u, err := url.Parse(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("'%s' is not a valid origin: %w", item, err)
+		}
+		origins = append(origins, fmt.Sprintf("%s://%s", u.Scheme, u.Host))
+	}
+	return origins, nil
+}
 
 // NewServer creates a new server instance
 func NewServer(ctx context.Context, config ServerConfig) (*Server, error) {
@@ -250,7 +337,50 @@ func (s *Server) Handler() http.Handler {
 
 // hostAuthorizationMiddleware enforces that the request Host header matches one of the allowed
 // hosts, ignoring any port in the comparison. If allowedHosts is empty, all hosts are allowed.
+// Always uses url.Parse("http://" + r.Host) to robustly extract the hostname (handles IPv6).
+func hostAuthorizationMiddleware(allowedHosts []string, badHostHandler http.Handler) func(next http.Handler) http.Handler {
+	// Copy for safety; also build a map for O(1) lookups with case-insensitive keys.
+	allowed := make(map[string]struct{}, len(allowedHosts))
+	for _, h := range allowedHosts {
+		allowed[strings.ToLower(h)] = struct{}{}
+	}
+	wildcard := slices.Contains(allowedHosts, "*")
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if wildcard { // wildcard semantics: allow all
+				next.ServeHTTP(w, r)
+				return
+			}
+			// Extract hostname from the Host header using url.Parse; ignore any port.
+			hostHeader := r.Host
+			if hostHeader == "" {
+				badHostHandler.ServeHTTP(w, r)
+				return
+			}
+			if u, err := url.Parse("http://" + hostHeader); err == nil {
+				hostname := u.Hostname()
+				if _, ok := allowed[strings.ToLower(hostname)]; ok {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+			badHostHandler.ServeHTTP(w, r)
+		})
+	}
+}
 
+// sseMiddleware creates middleware that prevents proxy buffering for SSE endpoints
+func sseMiddleware(ctx huma.Context, next func(huma.Context)) {
+	// Disable proxy buffering for SSE endpoints
+	ctx.SetHeader("Cache-Control", "no-cache, no-store, must-revalidate")
+	ctx.SetHeader("Pragma", "no-cache")
+	ctx.SetHeader("Expires", "0")
+	ctx.SetHeader("X-Accel-Buffering", "no") // nginx
+	ctx.SetHeader("X-Proxy-Buffering", "no") // generic proxy
+	ctx.SetHeader("Connection", "keep-alive")
+
+	next(ctx)
+}
 
 // registerRoutes sets up all API endpoints
 func (s *Server) registerRoutes() {
@@ -271,6 +401,51 @@ func (s *Server) registerRoutes() {
 
 	huma.Post(s.api, "/upload", s.uploadFiles, func(o *huma.Operation) {
 		o.Description = "Upload files to the specified upload path."
+	})
+
+	// DELETE /messages endpoint — clear the conversation history.
+	huma.Delete(s.api, "/messages", s.clearMessages, func(o *huma.Operation) {
+		o.Description = "Clears the conversation history with the agent."
+	})
+
+	// GET /messages/count endpoint.
+	huma.Get(s.api, "/messages/count", s.getMessagesCount, func(o *huma.Operation) {
+		o.Description = "Returns the number of messages in the conversation history."
+	})
+
+	// GET /info endpoint — agent version/type/feature flags.
+	huma.Get(s.api, "/info", s.getInfo, func(o *huma.Operation) {
+		o.Description = "Returns version, agent type, and feature flags for the running server."
+	})
+
+	// GET /config endpoint.
+	huma.Get(s.api, "/config", s.getConfig, func(o *huma.Operation) {
+		o.Description = "Returns the effective server configuration."
+	})
+
+	// GET /logs endpoint.
+	huma.Get(s.api, "/logs", s.getLogs, func(o *huma.Operation) {
+		o.Description = "Returns server log lines."
+	})
+
+	// GET /rate-limit endpoint.
+	huma.Get(s.api, "/rate-limit", s.getRateLimit, func(o *huma.Operation) {
+		o.Description = "Returns rate-limit status."
+	})
+
+	// GET /health endpoint.
+	huma.Get(s.api, "/health", s.getHealth, func(o *huma.Operation) {
+		o.Description = "Returns server health."
+	})
+
+	// GET /version endpoint.
+	huma.Get(s.api, "/version", s.getVersion, func(o *huma.Operation) {
+		o.Description = "Returns the server version."
+	})
+
+	// GET /ready endpoint.
+	huma.Get(s.api, "/ready", s.getReady, func(o *huma.Operation) {
+		o.Description = "Returns whether the server is ready to serve requests."
 	})
 
 	// GET /events endpoint
@@ -303,6 +478,188 @@ func (s *Server) registerRoutes() {
 
 	// Serve static files for the chat interface under /chat
 	s.registerStaticFileRoutes()
+}
+
+// getStatus handles GET /status
+func (s *Server) getStatus(ctx context.Context, input *struct{}) (*StatusResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	status := s.conversation.Status()
+	agentStatus, err := convertStatus(status)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to convert status: %w", err)
+	}
+
+	resp := &StatusResponse{}
+	resp.Body.Status = agentStatus
+	resp.Body.AgentType = s.agentType
+	resp.Body.Transport = s.transport
+
+	return resp, nil
+}
+
+// getMessages handles GET /messages
+func (s *Server) getMessages(ctx context.Context, input *struct{}) (*MessagesResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	resp := &MessagesResponse{}
+	resp.Body.Messages = make([]Message, len(s.conversation.Messages()))
+	for i, msg := range s.conversation.Messages() {
+		resp.Body.Messages[i] = Message{
+			Id:      msg.Id,
+			Role:    msg.Role,
+			Content: msg.Message,
+			Time:    msg.Time,
+		}
+	}
+
+	return resp, nil
+}
+
+// createMessage handles POST /message
+func (s *Server) createMessage(ctx context.Context, input *MessageRequest) (*MessageResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	switch input.Body.Type {
+	case MessageTypeUser:
+		if err := s.conversation.Send(FormatMessage(s.agentType, input.Body.Content)...); err != nil {
+			return nil, xerrors.Errorf("failed to send message: %w", err)
+		}
+	case MessageTypeRaw:
+		if _, err := s.agentio.Write([]byte(input.Body.Content)); err != nil {
+			return nil, xerrors.Errorf("failed to send message: %w", err)
+		}
+	}
+
+	resp := &MessageResponse{}
+	resp.Body.Ok = true
+
+	return resp, nil
+}
+
+// uploadFiles handles POST /upload
+func (s *Server) uploadFiles(ctx context.Context, input *struct {
+	RawBody huma.MultipartFormFiles[UploadRequest]
+},
+) (*UploadResponse, error) {
+	formData := input.RawBody.Data()
+
+	file := formData.File.File
+
+	// Limit file size to 10MB
+	const maxFileSize = 10 << 20 // 10MB
+	buf, err := io.ReadAll(io.LimitReader(file, maxFileSize+1))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to upload file: %w", err)
+	}
+	if len(buf) > maxFileSize {
+		return nil, huma.Error400BadRequest("file size exceeds 10MB limit")
+	}
+
+	// Calculate checksum of the uploaded file to create unique subdirectory
+	hash := sha256.Sum256(buf)
+	checksum := hex.EncodeToString(hash[:8]) // Use first 8 bytes (16 hex chars)
+
+	// Create checksum-based subdirectory in tempDir
+	uploadDir := filepath.Join(s.tempDir, checksum)
+	err = os.MkdirAll(uploadDir, 0o755)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create upload directory: %w", err)
+	}
+
+	// Save individual file with original filename (extract just the base filename for security)
+	filename := filepath.Base(formData.File.Filename)
+
+	outPath := filepath.Join(uploadDir, filename)
+	err = os.WriteFile(outPath, buf, 0o644)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to write file: %w", err)
+	}
+
+	resp := &UploadResponse{}
+	resp.Body.Ok = true
+	resp.Body.FilePath = outPath
+	return resp, nil
+}
+
+// subscribeEvents is an SSE endpoint that sends events to the client
+func (s *Server) subscribeEvents(ctx context.Context, input *struct{}, send sse.Sender) {
+	subscriberId, ch, stateEvents := s.emitter.Subscribe()
+	defer s.emitter.Unsubscribe(subscriberId)
+
+	s.logger.Info("New subscriber", "subscriberId", subscriberId)
+	for _, event := range stateEvents {
+		if event.Type == EventTypeScreenUpdate {
+			continue
+		}
+		if err := send.Data(event.Payload); err != nil {
+			s.logger.Error("Failed to send event", "subscriberId", subscriberId, "error", err)
+			return
+		}
+	}
+
+	for {
+		select {
+		case event, ok := <-ch:
+			if !ok {
+				s.logger.Info("Channel closed", "subscriberId", subscriberId)
+				return
+			}
+			if event.Type == EventTypeScreenUpdate {
+				continue
+			}
+			if err := send.Data(event.Payload); err != nil {
+				s.logger.Error("Failed to send event", "subscriberId", subscriberId, "error", err)
+				return
+			}
+		case <-s.shutdownCtx.Done():
+			s.logger.Info("Server stop initiated, unsubscribing.", "subscriberId", subscriberId)
+			return
+		case <-ctx.Done():
+			s.logger.Info("Context done", "subscriberId", subscriberId)
+			return
+		}
+	}
+}
+
+func (s *Server) subscribeScreen(ctx context.Context, input *struct{}, send sse.Sender) {
+	subscriberId, ch, stateEvents := s.emitter.Subscribe()
+	defer s.emitter.Unsubscribe(subscriberId)
+	s.logger.Info("New screen subscriber", "subscriberId", subscriberId)
+	for _, event := range stateEvents {
+		if event.Type != EventTypeScreenUpdate {
+			continue
+		}
+		if err := send.Data(event.Payload); err != nil {
+			s.logger.Error("Failed to send screen event", "subscriberId", subscriberId, "error", err)
+			return
+		}
+	}
+	for {
+		select {
+		case event, ok := <-ch:
+			if !ok {
+				s.logger.Info("Screen channel closed", "subscriberId", subscriberId)
+				return
+			}
+			if event.Type != EventTypeScreenUpdate {
+				continue
+			}
+			if err := send.Data(event.Payload); err != nil {
+				s.logger.Error("Failed to send screen event", "subscriberId", subscriberId, "error", err)
+				return
+			}
+		case <-s.shutdownCtx.Done():
+			s.logger.Info("Server stop initiated, unsubscribing.", "subscriberId", subscriberId)
+			return
+		case <-ctx.Done():
+			s.logger.Info("Screen context done", "subscriberId", subscriberId)
+			return
+		}
+	}
 }
 
 // Start starts the HTTP server
@@ -358,4 +715,14 @@ func (s *Server) registerStaticFileRoutes() {
 	// Mount the file server at /chat
 	s.router.Handle("/chat", http.StripPrefix("/chat", chatHandler))
 	s.router.Handle("/chat/*", http.StripPrefix("/chat", chatHandler))
+}
+
+func (s *Server) redirectToChat(w http.ResponseWriter, r *http.Request) {
+	rdir, err := url.JoinPath(s.chatBasePath, "embed")
+	if err != nil {
+		s.logger.Error("Failed to construct redirect URL", "error", err)
+		http.Error(w, "Failed to redirect", http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, rdir, http.StatusTemporaryRedirect)
 }

--- a/x/acpio/acp_conversation.go
+++ b/x/acpio/acp_conversation.go
@@ -77,6 +77,15 @@ func NewACPConversation(ctx context.Context, agentIO ChunkableAgentIO, logger *s
 	return c
 }
 
+// ClearMessages removes all messages from the conversation history.
+func (c *ACPConversation) ClearMessages() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.messages = nil
+	c.nextID = 0
+	c.streamingResponse.Reset()
+}
+
 // Messages returns the conversation history.
 func (c *ACPConversation) Messages() []st.ConversationMessage {
 	c.mu.Lock()


### PR DESCRIPTION
## **User description**
## Summary\n- Restore lib/httpapi/server.go handlers removed in #531 upstream sync (parseAllowedHosts, core conversation/SSE routes).\n- Implement ClearMessages on x/acpio.ACPConversation for screentracker.Conversation.\n\n## Context\nphenotype-gateway H9 smoke (PR #6) fails agentapi-plusplus at pin 7898704.\n\n## Test plan\n- [x] go build ./...

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Restore the H9 gateway routes and conversation reset behavior**

### What Changed
- Restores the HTTP routes needed for the gateway smoke run, including the core status, message, upload, event, and screen endpoints
- Adds a way to clear the conversation history, which also resets message numbering and any in-progress streamed response
- Tightens host and origin checks so invalid values are rejected with clearer errors, while still allowing a wildcard setting
- Improves SSE responses so event streams are less likely to be buffered by proxies

### Impact
`✅ Fewer gateway smoke test failures`
`✅ Clearer conversation resets`
`✅ Safer host and origin configuration`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
