### PR TITLE
fix(p3): remediate next audit findings

### DIFF
--- a/cmd/attach/attach.go
+++ b/cmd/attach/attach.go
@@ -128,8 +128,19 @@ func WriteRawInputOverHTTP(ctx context.Context, url string, msg string) error {
 	return nil
 }
 
+// checkACPModeHTTPTimeout bounds how long the attach CLI will wait for the
+// server's /status endpoint before giving up. Without it a hung server
+// would block the CLI indefinitely, leaking the goroutine and the TTY
+// (audit finding L26).
+const checkACPModeHTTPTimeout = 5 * time.Second
+
 func checkACPMode(remoteURL string) (bool, error) {
-	resp, err := http.Get(remoteURL + "/status")
+	client := &http.Client{Timeout: checkACPModeHTTPTimeout}
+	req, err := http.NewRequest(http.MethodGet, remoteURL+"/status", nil)
+	if err != nil {
+		return false, xerrors.Errorf("failed to build status request: %w", err)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return false, xerrors.Errorf("failed to check server status: %w", err)
 	}

--- a/cmd/attach/attach_test.go
+++ b/cmd/attach/attach_test.go
@@ -1,0 +1,89 @@
+package attach
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+// TestCheckACPModeHTTPTimeout_HungServer verifies the new client-side
+// timeout (audit finding L26): when the server never replies, the call
+// must give up within `checkACPModeHTTPTimeout + a small slack` rather
+// than blocking forever.
+func TestCheckACPModeHTTPTimeout_HungServer(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Sleep far longer than the client's timeout so the client side
+		// is what fails first.
+		time.Sleep(2 * checkACPModeHTTPTimeout)
+		_, _ = w.Write([]byte("late"))
+	}))
+	defer srv.Close()
+
+	start := time.Now()
+	isACP, err := checkACPMode(srv.URL)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected timeout error from hung server, got nil (isACP=%v)", isACP)
+	}
+	// The error must be a network-level failure (timeout or refused),
+	// not an HTTP status code — the server never got to respond.
+	if !strings.Contains(err.Error(), "failed to check server status") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Underlying transport error must be a timeout-shaped error.
+	if inner := xerrors.Unwrap(err); inner == nil {
+		t.Fatalf("expected wrapped error, got bare %v", err)
+	}
+
+	// Allow a 2x slack for slow CI; the core invariant is "didn't hang".
+	if elapsed > 2*checkACPModeHTTPTimeout {
+		t.Fatalf("checkACPMode blocked for %s (timeout is %s)", elapsed, checkACPModeHTTPTimeout)
+	}
+}
+
+// TestCheckACPMode_HappyPath_ACP confirms a 200 + TransportACP body
+// is correctly detected, so the timeout change didn't break the
+// existing happy path.
+func TestCheckACPMode_HappyPath_ACP(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// TransportACP string is whatever the httpapi package reports;
+		// the wire-level contract is "non-empty string != legacy".
+		_, _ = w.Write([]byte(`{"transport":"acp"}`))
+	}))
+	defer srv.Close()
+
+	isACP, err := checkACPMode(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isACP {
+		t.Fatalf("expected isACP=true for transport=acp body")
+	}
+}
+
+// TestCheckACPMode_HappyPath_NonACP confirms a non-ACP body returns
+// (false, nil) instead of an error — the CLI then proceeds to attach.
+func TestCheckACPMode_HappyPath_NonACP(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"transport":"legacy"}`))
+	}))
+	defer srv.Close()
+
+	isACP, err := checkACPMode(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isACP {
+		t.Fatalf("expected isACP=false for transport=legacy body")
+	}
+}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"crypto/subtle"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -52,11 +53,23 @@ func APIKeyAuth(expectedKey string) func(next http.Handler) http.Handler {
 			// Header must be of the form "Bearer <token>".
 			const prefix = "Bearer "
 			if len(authz) <= len(prefix) || authz[:len(prefix)] != prefix {
+				slog.Warn("auth rejected",
+					slog.String("reason", "missing_or_malformed_authorization"),
+					slog.String("method", r.Method),
+					slog.String("path", r.URL.Path),
+					slog.String("remote", r.RemoteAddr),
+				)
 				writeUnauthorized(w, challengeJSON)
 				return
 			}
 			provided := []byte(authz[len(prefix):])
 			if !constantTimeEqual(provided, expected, expectedLen) {
+				slog.Warn("auth rejected",
+					slog.String("reason", "invalid_api_key"),
+					slog.String("method", r.Method),
+					slog.String("path", r.URL.Path),
+					slog.String("remote", r.RemoteAddr),
+				)
 				writeUnauthorized(w, challengeJSON)
 				return
 			}
@@ -88,11 +101,23 @@ func HumaAPIKeyAuth(expectedKey string) func(huma.Context, func(huma.Context)) {
 		authz := ctx.Header("Authorization")
 		const prefix = "Bearer "
 		if len(authz) <= len(prefix) || authz[:len(prefix)] != prefix {
+			slog.Warn("auth rejected",
+				slog.String("reason", "missing_or_malformed_authorization"),
+				slog.String("op", ctx.Operation().OperationID),
+				slog.String("method", ctx.Method()),
+				slog.String("path", ctx.URL().Path),
+			)
 			writeHumaUnauthorized(ctx, challengeJSON)
 			return
 		}
 		provided := []byte(authz[len(prefix):])
 		if !constantTimeEqual(provided, expected, expectedLen) {
+			slog.Warn("auth rejected",
+				slog.String("reason", "invalid_api_key"),
+				slog.String("op", ctx.Operation().OperationID),
+				slog.String("method", ctx.Method()),
+				slog.String("path", ctx.URL().Path),
+			)
 			writeHumaUnauthorized(ctx, challengeJSON)
 			return
 		}


### PR DESCRIPTION
## **User description**
P3 remediation — top unaddressed findings from focused self-audit (no v37 scorecard was generated for this fork, so the audit was a manual sweep over the Go surface).

Fixes:
- L26 — resilience: cmd/attach/checkACPMode no longer uses the bare http.Get default client (no timeout). Replace with a dedicated http.Client with 5s Timeout + explicit GET via http.NewRequest so a hung server can't block the CLI indefinitely or leak the TTY. Constant lives next to the function as checkACPModeHTTPTimeout.
- L5/L23 — observability: both APIKeyAuth (http.Handler middleware) and HumaAPIKeyAuth (huma.Context middleware) now emit a structured slog.Warn event on every rejection with a stable reason field (missing_or_malformed_authorization | invalid_api_key), op/method/path/remote correlation fields, and never logs the token itself.
- L26 — regression coverage: attach_test.go adds three tests (hung-server timeout, ACP happy-path, non-ACP happy-path) so the new client surface is guarded against future regressions.

Scope: 3 files, +126/-1 lines. No mass-delete, no rename. No new dependencies.

Verification (local):
- go build ./... — clean
- go vet ./cmd/attach/... ./internal/middleware/... — clean
- go test -timeout 60s ./cmd/attach/... ./internal/middleware/... — both packages pass (attach: 10.3s including the 5s timeout test; middleware: 0.17s, 9 pre-existing tests).


___

## **CodeAnt-AI Description**
**Stop attach from hanging on a stalled server and log rejected logins more clearly**

### What Changed
- The attach CLI now gives up after 5 seconds when checking server status, instead of waiting forever on a stalled `/status` response.
- API key rejections now create a warning log with the reason and request details, making failed logins easier to trace without exposing the key.
- Added coverage for the attach timeout and both attach detection paths so the new behavior stays in place.

### Impact
`✅ Fewer attach sessions that hang forever`
`✅ Clearer failed login tracing`
`✅ Safer auth failure logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
