### PR TITLE
ci: 修正 fork 的 release workflow，可自行編譯發佈 binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,77 +1,74 @@
 name: Build Release Binaries
 
+# 發佈 release（publish）時自動編譯 agentapi binary 並掛上 release 資產。
+# 注意：不使用 repo 的 make build / task build:go —— 該路徑缺少 chat UI 嵌入步驟
+# （next build 產物需先複製進 lib/httpapi/chat/ 供 go:embed 打包），
+# 因此以下直接照上游 coder/agentapi Makefile 的流程執行。
+
 permissions:
-  contents: read
+  contents: write
 
 on:
   release:
     types: [published]
-  push:
-    branches: [ main ]
   workflow_dispatch:
-    inputs:
-      create-artifact:
-        description: 'Create build artifact'
-        required: true
-        type: boolean
-        default: false
 
 jobs:
   build:
     name: Build Release Binaries
-    runs-on: ubuntu-latest-8-cores
-    if: ${{ github.repository_owner == 'coder' }}
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
-      with:
-        go-version: 'stable'
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
-    - name: Set up Bun
-      uses: oven-sh/setup-bun@v2
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
 
-    - name: Install Chat Dependencies
-      run: cd chat && bun install
+      - name: Build chat UI
+        # BASE_PATH 必須是 lib/httpapi/embed.go 的 magicBasePath，
+        # binary 啟動時才能把它改寫成實際的 chat base path（AGENTAPI_CHAT_BASE_PATH）
+        run: |
+          cd chat
+          bun install --frozen-lockfile
+          NEXT_PUBLIC_BASE_PATH="/magic-base-path-placeholder" bun run build
 
-    - name: Run make gen and check for unstaged changes
-      run: |
-        make gen
-        ./check_unstaged.sh
+      - name: Embed chat UI
+        run: |
+          rm -rf lib/httpapi/chat
+          mkdir -p lib/httpapi/chat
+          touch lib/httpapi/chat/marker
+          cp -r chat/out/. lib/httpapi/chat/
 
-    - name: Build and Upload
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      shell: bash
-      run: |
-        build_variants=(
-          "linux amd64 agentapi-linux-amd64"
-          "linux arm64 agentapi-linux-arm64"
-          "darwin amd64 agentapi-darwin-amd64"
-          "darwin arm64 agentapi-darwin-arm64"
-          "windows amd64 agentapi-windows-amd64.exe"
-        )
+      - name: Build binaries
+        run: |
+          build_variants=(
+            "linux amd64 agentapi-linux-amd64"
+            "linux arm64 agentapi-linux-arm64"
+            "darwin amd64 agentapi-darwin-amd64"
+            "darwin arm64 agentapi-darwin-arm64"
+          )
+          for variant in "${build_variants[@]}"; do
+            read -r goos goarch artifact_name <<< "$variant"
+            echo "Building $artifact_name..."
+            CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+              go build -o "out/$artifact_name" main.go
+          done
 
-        for variant in "${build_variants[@]}"; do
-          read -r goos goarch artifact_name <<< "$variant"
+      - name: Upload build artifact
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentapi-build
+          path: out/
+          retention-days: 7
 
-          echo "Building for GOOS=$goos GOARCH=$goarch..."
-          CGO_ENABLED=0 GOOS=$goos GOARCH=$goarch BINPATH="out/$artifact_name" make build
-        done
-
-    - name: Upload Build Artifact
-      if: ${{ inputs.create-artifact }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: agentapi-build
-        path: ${{ github.workspace }}/out
-        retention-days: 7
-
-    - name: Upload Release Assets
-      if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' }}
-      run: gh release upload "$RELEASE_TAG" "$GITHUB_WORKSPACE"/out/* --clobber
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || 'preview' }}
+      - name: Upload release assets
+        if: ${{ github.event_name == 'release' }}
+        run: gh release upload "${{ github.event.release.tag_name }}" out/* --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## **User description**
- 移除 repository_owner == 'coder' gate（fork 上永遠不會執行）
- ubuntu-latest-8-cores 改為 ubuntu-latest（個人 repo 無此 runner）
- permissions 改為 contents: write（上傳 release 資產所需）
- 不走 make build / task build:go：該路徑缺少 chat UI 嵌入步驟， 改照上游 coder/agentapi Makefile 流程（NEXT_PUBLIC_BASE_PATH=magic base path build chat → 複製進 lib/httpapi/chat → go build）
- 移除 push main 觸發（原本會上傳到不存在的 preview release）

## Summary

<!-- Describe what this PR does and why it is needed. -->

## Changes

- 

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Test coverage maintained or improved

## Validation

- [ ] Lint/format checks passed
- [ ] Build/test commands documented and successful
- [ ] Documentation updated (if needed)

## Merge Readiness

- [ ] PR is labeled `automerge` for automatic merge flow (optional)
- [ ] Conflicts resolved

## Related Issues

Closes: 



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix release workflow to build and publish binaries from forks
> - Updates [release.yml](.github/workflows/release.yml) to grant `contents: write` permission so release assets can be uploaded.
> - Removes the `repository_owner == 'coder'` guard, allowing forks to run the workflow.
> - Adds a Bun-based chat UI build step that embeds assets into `lib/httpapi/chat/` before compiling binaries.
> - Replaces `make build` with explicit `go build` for four targets: `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`; Windows builds are removed.
> - On `workflow_dispatch`, uploads build artifacts from `out/`; on release publish, uploads binaries as release assets using the release tag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d266e84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


___

## **CodeAnt-AI Description**
**Fix release builds so forks can publish binaries**

### What Changed
- Release workflows now run in forks and can upload release files successfully
- The build process now includes the chat UI before compiling the binaries, so the published app starts with the embedded chat content
- Main-branch push runs were removed, and manual runs now produce a downloadable build artifact
- Builds now use standard runners instead of a runner type that may not exist in personal repositories

### Impact
`✅ Forks can publish release binaries`
`✅ Fewer broken release downloads`
`✅ Working chat UI in shipped builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds now bundle the chat interface directly into the published binaries, so it ships with the app out of the box.

* **Chores**
  * Streamlined the release pipeline to build fewer binary variants and simplify packaging.
  * Artifact uploads are now separated more cleanly between manual workflows and published releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->